### PR TITLE
feat(prometheus-sidecar): M1-M5 — full Prometheus ecosystem integration

### DIFF
--- a/backend/alembic/versions/033_add_alert_rule_query_expr.py
+++ b/backend/alembic/versions/033_add_alert_rule_query_expr.py
@@ -1,0 +1,44 @@
+"""add query_expr + for_duration to alert_rules
+
+Revision ID: 033_add_alert_rule_query_expr
+Revises: 032_add_host_status_heartbeat_index
+Create Date: 2026-04-21
+
+背景 (Context):
+    Prometheus 集成 Milestone 2：允许 AlertRule 使用原生 PromQL 表达式触发告警。
+    - query_expr: PromQL 表达式（如 rate(http_requests_total{status=~"5.."}[5m]) > 0.1）
+    - for_duration_seconds: 表达式持续满足的时间，映射到 Prometheus 规则的 for 字段
+    - prom_rule_synced_at: 上次同步到 /etc/prometheus/rules/*.yml 的时间戳
+
+向后兼容：所有字段可空；既有 metric+threshold 规则保持原路径执行。
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "033_add_alert_rule_query_expr"
+down_revision = "032_add_host_status_heartbeat_index"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "alert_rules",
+        sa.Column("query_expr", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "alert_rules",
+        sa.Column("for_duration_seconds", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "alert_rules",
+        sa.Column("prom_rule_synced_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("alert_rules", "prom_rule_synced_at")
+    op.drop_column("alert_rules", "for_duration_seconds")
+    op.drop_column("alert_rules", "query_expr")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -143,6 +143,8 @@ class Settings(BaseSettings):
     prometheus_remote_enabled: bool = False
     prometheus_remote_url: str = "http://prometheus:9090"
     prometheus_remote_timeout_seconds: float = 15.0
+    # Remote Write 接收端点 Bearer token；空 = 拒绝所有 Bearer 调用（仅允许 User JWT）
+    prom_remote_write_token: str = ""
 
     # AlertManager Bridge 配置 (AlertManager Bridge Configuration)
     alertmanager_webhook_token: str = ""  # Bearer token for webhook auth, generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -137,6 +137,13 @@ class Settings(BaseSettings):
     webhook_allowed_domains: str = ""  # 例如: "api.example.com,webhook.example.com"
     webhook_enable_ssl_verification: bool = True  # 是否启用 SSL 证书验证 (Enable SSL Certificate Verification)
 
+    # Prometheus sidecar 配置 (Prometheus sidecar configuration)
+    # 启用后 /api/v1/promql/* 请求会转发到 sidecar 而非内置 mini 引擎。
+    # 默认 false 保持向后兼容；docker compose --profile prometheus 启用 sidecar 时开启。
+    prometheus_remote_enabled: bool = False
+    prometheus_remote_url: str = "http://prometheus:9090"
+    prometheus_remote_timeout_seconds: float = 15.0
+
     # AlertManager Bridge 配置 (AlertManager Bridge Configuration)
     alertmanager_webhook_token: str = ""  # Bearer token for webhook auth, generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
     alertmanager_auto_threshold: float = 0.9  # AI 信心分数 >= 此值时自动执行修复 (Auto-execute when confidence >= this)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -76,6 +76,7 @@ from app.routers import ai_analysis
 from app.routers import custom_runbooks
 from app.routers import promql
 from app.routers import webhooks
+from app.routers import prom_remote_write  # noqa: E402  (main.py 存量 E402 debt 规避)
 from app.routers import alert_stream
 from app.api.v1 import data_retention
 from app.api.v1 import alert_deduplication
@@ -314,6 +315,7 @@ app.include_router(ai_analysis.router)  # AI 分析 (AI analysis: insights, root
 app.include_router(custom_runbooks.router)  # 自定义 Runbook 管理 (Custom Runbook Management)
 app.include_router(promql.router)  # PromQL 查询 (PromQL Query Engine)
 app.include_router(webhooks.router)  # 外部告警源 Webhook (External Alert Source Webhooks)
+app.include_router(prom_remote_write.router)  # Prometheus Remote Write 接收器 (Prometheus Remote Write Receiver)
 app.include_router(alert_stream.router)  # 告警诊断 SSE 流 (Alert Diagnosis SSE Stream)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -168,6 +168,11 @@ async def lifespan(app: FastAPI):
         from app.tasks.remediation_listener import remediation_listener_loop
         task_factories["remediation_listener"] = lambda: remediation_listener_loop()
 
+    # Prometheus file_sd 同步任务（仅在启用 sidecar 时）
+    if app_settings.prometheus_remote_enabled:
+        from app.tasks.prom_file_sd_task import prom_file_sd_loop
+        task_factories["prom_file_sd"] = lambda: prom_file_sd_loop()
+
     # 启动所有任务
     for name, factory in task_factories.items():
         background_tasks[name] = asyncio.create_task(factory(), name=name)

--- a/backend/app/models/alert.py
+++ b/backend/app/models/alert.py
@@ -43,6 +43,11 @@ class AlertRule(Base):
     is_enabled: Mapped[bool] = mapped_column(Boolean, default=True)  # 是否启用该规则 (Is Rule Enabled)
     target_type: Mapped[str] = mapped_column(String(20), nullable=False, default="host")  # 目标类型：主机/服务 (Target Type: host/service)
     target_filter: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)  # 目标过滤条件 JSON (Target Filter Conditions)
+    # Prometheus PromQL 告警字段 (Prometheus PromQL Alerting Fields)
+    # 非空时走 sidecar 触发路径；为空时走既有 metric+threshold 路径。
+    query_expr: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # PromQL 表达式 (PromQL expression)
+    for_duration_seconds: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)  # 表达式持续满足的时长（Prom for 语义）
+    prom_rule_synced_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)  # 上次同步到 rules.yml 时间
     # 日志关键字告警字段 (Log Keyword Alert Fields)
     rule_type: Mapped[Optional[str]] = mapped_column(String(20), nullable=True, default="metric")  # 规则类型：指标/日志关键字/数据库 (Rule Type: metric/log_keyword/db_metric)
     log_keyword: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # 日志关键字 (Log Keyword)

--- a/backend/app/routers/alert_rules.py
+++ b/backend/app/routers/alert_rules.py
@@ -29,6 +29,7 @@ from app.models.alert_group import AlertDeduplication
 from app.models.user import User
 from app.schemas.alert import AlertRuleCreate, AlertRuleUpdate, AlertRuleResponse
 from app.services.audit import log_audit
+from app.services.prom_file_sd import sync_file_sd
 from app.services.prom_rules_sync import sync_rules_to_prometheus
 
 import logging
@@ -293,6 +294,25 @@ async def sync_prom_rules_manually(
     """
     stats = await sync_rules_to_prometheus(db, reload_sidecar=True)
     await log_audit(db, _user.id, "prom_rules_sync", "alert_rule", 0,
+                    json.dumps(stats),
+                    request.client.host if request.client else None)
+    return {"status": "ok", **stats}
+
+
+@router.post("/prometheus/file-sd-sync")
+async def sync_file_sd_manually(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(get_operator_user),
+):
+    """
+    手动全量导出 Host / Service 到 Prometheus file_sd targets。
+
+    日常运行由 prom_file_sd 后台任务每 60s 触发；
+    此端点用于：Host 大批导入后立刻推送、targets 目录被清空后快速恢复、诊断。
+    """
+    stats = await sync_file_sd(db)
+    await log_audit(db, _user.id, "prom_file_sd_sync", "alert_rule", 0,
                     json.dumps(stats),
                     request.client.host if request.client else None)
     return {"status": "ok", **stats}

--- a/backend/app/routers/alert_rules.py
+++ b/backend/app/routers/alert_rules.py
@@ -29,6 +29,20 @@ from app.models.alert_group import AlertDeduplication
 from app.models.user import User
 from app.schemas.alert import AlertRuleCreate, AlertRuleUpdate, AlertRuleResponse
 from app.services.audit import log_audit
+from app.services.prom_rules_sync import sync_rules_to_prometheus
+
+import logging
+
+_sync_logger = logging.getLogger("nightmend.alert_rules.prom_sync")
+
+
+async def _best_effort_sync(db: AsyncSession) -> None:
+    """写 rules.yml + reload，失败只记日志不阻塞主流程（API 返回已成功）。"""
+    try:
+        await sync_rules_to_prometheus(db, reload_sidecar=True)
+    except Exception as exc:  # noqa: BLE001
+        _sync_logger.warning("Prometheus rule sync failed (non-fatal): %s", exc)
+
 
 router = APIRouter(prefix="/api/v1/alert-rules", tags=["alert-rules"])
 
@@ -99,6 +113,9 @@ async def create_alert_rule(
                     request.client.host if request.client else None)
     await db.commit()
     await db.refresh(rule)
+    # query_expr 非空时同步到 Prometheus rules.yml（开关关闭时内部会短路）
+    if rule.query_expr:
+        await _best_effort_sync(db)
     return rule
 
 
@@ -203,6 +220,12 @@ async def update_alert_rule(
                     request.client.host if request.client else None)
     await db.commit()
     await db.refresh(rule)
+    # 触发 Prom 规则同步：
+    #   - 本身已经是 PromQL 规则（含/曾含 query_expr）
+    #   - 或本次更新动了 query_expr / is_enabled / for_duration_seconds
+    prom_fields = {"query_expr", "is_enabled", "for_duration_seconds"}
+    if rule.query_expr or (updates.keys() & prom_fields):
+        await _best_effort_sync(db)
     return rule
 
 
@@ -246,5 +269,30 @@ async def delete_alert_rule(
     await log_audit(db, _user.id, "delete_alert_rule", "alert_rule", rule_id,
                     None,  # 删除操作不需要记录具体内容
                     request.client.host if request.client else None)
+    had_query_expr = bool(rule.query_expr)
     await db.delete(rule)  # 从数据库中物理删除规则
     await db.commit()
+    # 被删的是 PromQL 规则 → 让 sidecar 移除它
+    if had_query_expr:
+        await _best_effort_sync(db)
+
+
+@router.post("/prometheus/sync")
+async def sync_prom_rules_manually(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(get_operator_user),
+):
+    """
+    手动全量同步 AlertRule (query_expr 非空 & is_enabled) 到 Prometheus rules.yml。
+
+    使用场景：
+        - sidecar 迁移后首次全量推送
+        - rules.yml 被外部工具污染后的强制修复
+        - 升级 for_duration 默认值/标签策略后的一次性刷盘
+    """
+    stats = await sync_rules_to_prometheus(db, reload_sidecar=True)
+    await log_audit(db, _user.id, "prom_rules_sync", "alert_rule", 0,
+                    json.dumps(stats),
+                    request.client.host if request.client else None)
+    return {"status": "ok", **stats}

--- a/backend/app/routers/prom_remote_write.py
+++ b/backend/app/routers/prom_remote_write.py
@@ -1,0 +1,142 @@
+"""Prometheus Remote Write 接收器 (Prometheus Remote Write Receiver)
+
+顶层逻辑：
+    外部 Prometheus 集群把数据 push 到 NightMend，让 NightMend 成为多集群的
+    AI 分析 / 告警聚合中心。我们**不**在 Python 里解 snappy+protobuf——而是
+    作为鉴权透明代理，把原始 body 转发给 sidecar 的 /api/v1/write（Prom
+    v2.33+ 的 remote_write_receiver 能力，docker-compose 里已用
+    --web.enable-remote-write-receiver 启用）。
+
+收益（vs. 自己解协议）：
+    - 零新增依赖：不用 python-snappy / protobuf generated classes
+    - 协议永远兼容最新 Prom：Prom 升级新格式我们自动跟随
+    - 性能：纯 httpx bytes 转发，省掉反序列化 CPU
+    - NightMend 只做"看门人"：鉴权 + 审计 + 限流 + 租户路由
+
+请求契约（Prometheus spec）:
+    POST /api/v1/prom/remote_write
+    Content-Encoding: snappy
+    Content-Type: application/x-protobuf
+    X-Prometheus-Remote-Write-Version: 0.1.0
+    Body: snappy-compressed protobuf WriteRequest
+
+响应：
+    - 204 No Content 成功（对齐 Prom 标准）
+    - 401 未鉴权
+    - 413 body 超限
+    - 429 超限流
+    - 502 sidecar 不可达（Prom 客户端会重试）
+"""
+from __future__ import annotations
+
+import logging
+
+import hmac
+
+import httpx
+from fastapi import APIRouter, HTTPException, Request, Response, status
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/prom", tags=["prom-remote-write"])
+
+# 10 MB 上限，防止单次 push 打满内存；标准 Prom remote_write 单批一般 <1MB
+_MAX_BODY_BYTES = 10 * 1024 * 1024
+
+
+def _authenticate_remote_write(request: Request) -> str:
+    """
+    Bearer token 鉴权（machine-to-machine 专用）。
+    成功返回审计标识（token 前 6 字符），绝不回显全量。
+    """
+    auth = request.headers.get("authorization", "")
+    if not auth.startswith("Bearer "):
+        raise HTTPException(
+            status_code=401,
+            detail="Missing Authorization: Bearer <token>",
+        )
+    token = auth[7:]
+    expected = settings.prom_remote_write_token
+    if not expected:
+        raise HTTPException(
+            status_code=503,
+            detail="Remote write token not configured",
+        )
+    if not hmac.compare_digest(token, expected):
+        raise HTTPException(status_code=401, detail="Invalid bearer token")
+    return f"bearer:{token[:6]}***"
+
+
+async def _forward_to_sidecar(body: bytes, headers: dict[str, str]) -> int:
+    """把 body 原封不动转发到 Prom sidecar 的 /api/v1/write。"""
+    base = settings.prometheus_remote_url.rstrip("/")
+    # 只透传 remote_write 协议需要的头，避免把 NightMend 自己的 cookie/auth 泄给 Prom
+    fwd_headers = {
+        k: v for k, v in headers.items()
+        if k.lower() in {
+            "content-encoding",
+            "content-type",
+            "x-prometheus-remote-write-version",
+        }
+    }
+    try:
+        async with httpx.AsyncClient(timeout=settings.prometheus_remote_timeout_seconds) as client:
+            response = await client.post(f"{base}/api/v1/write", content=body, headers=fwd_headers)
+    except httpx.RequestError as exc:
+        logger.warning("Remote write forward failed: %s", exc)
+        raise HTTPException(status_code=502, detail=f"Prometheus sidecar unreachable: {exc}")
+
+    if response.status_code >= 400:
+        logger.warning(
+            "Prometheus sidecar rejected remote_write: status=%s body=%s",
+            response.status_code, response.text[:200],
+        )
+        # 标准做法：Prom 4xx 视为数据不合法透传，5xx 视为 502 让客户端重试
+        if 400 <= response.status_code < 500:
+            raise HTTPException(status_code=response.status_code, detail=response.text[:500])
+        raise HTTPException(status_code=502, detail="Prometheus sidecar returned 5xx")
+
+    return response.status_code
+
+
+@router.post("/remote_write", status_code=status.HTTP_204_NO_CONTENT)
+async def receive_remote_write(request: Request, response: Response):
+    """
+    Prometheus Remote Write 接收端点。
+
+    典型 alertmanager.yml / prometheus.yml 客户端配置：
+        remote_write:
+          - url: "https://nightmend.example.com/api/v1/prom/remote_write"
+            authorization:
+              type: Bearer
+              credentials: "<NIGHTMEND_PROM_REMOTE_WRITE_TOKEN>"
+    """
+    if not settings.prometheus_remote_enabled:
+        raise HTTPException(
+            status_code=503,
+            detail="Remote write disabled; set PROMETHEUS_REMOTE_ENABLED=true",
+        )
+
+    # 1. 鉴权
+    caller = _authenticate_remote_write(request)
+
+    # 2. 读 body 并限长
+    body = await request.body()
+    if len(body) > _MAX_BODY_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Body too large ({len(body)} bytes, max {_MAX_BODY_BYTES})",
+        )
+    if not body:
+        raise HTTPException(status_code=400, detail="Empty body")
+
+    # 3. 转发到 sidecar（纯 bytes passthrough）
+    upstream_status = await _forward_to_sidecar(body, dict(request.headers))
+    logger.info(
+        "remote_write proxied: caller=%s bytes=%d upstream=%s",
+        caller, len(body), upstream_status,
+    )
+    # Prom 期望 204；但若 sidecar 返回 200 也应透传 OK
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/services/prom_file_sd.py
+++ b/backend/app/services/prom_file_sd.py
@@ -1,0 +1,190 @@
+"""Prometheus file_sd targets 导出器 (Prometheus file_sd Targets Exporter)
+
+顶层逻辑：
+    NightMend 的 Host / Service 表是"真源"，Prometheus sidecar 需要订阅这个真源
+    才能动态发现 scrape 目标。这里把两类来源合成 Prometheus file_sd 文件：
+
+      - host_exporter_port: 每台主机若暴露了 node_exporter（默认 9100），导出为一条
+        {targets: ["host_ip:9100"], labels: {hostname, group, target_type=host}}
+      - Service: type=http/tcp 且有可提取 host:port 的，导出为服务级 target
+
+    Prometheus 用 file_sd_configs 订阅 /etc/prometheus/targets/*.json，Prom 进程
+    每 refresh_interval（30s）重读文件，无需 reload。
+
+输出文件：
+    /etc/prometheus/targets/hosts.json
+    /etc/prometheus/targets/services.json
+
+配置规范：
+    https://prometheus.io/docs/prometheus/latest/configuration/configuration/#file_sd_config
+    JSON 顶层是 list<{ "targets": [str], "labels": {str: str} }>
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlparse
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.host import Host
+from app.models.service import Service
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TARGETS_DIR = os.environ.get(
+    "NIGHTMEND_PROM_TARGETS_DIR",
+    "/etc/prometheus/targets",
+)
+
+# node_exporter 默认端口；允许通过 env 覆盖
+DEFAULT_NODE_EXPORTER_PORT = int(os.environ.get("NIGHTMEND_NODE_EXPORTER_PORT", "9100"))
+
+
+def _primary_ip(host: Host) -> str | None:
+    """取主机的可达 IP：优先 private，其次 ip_address，最后 public。"""
+    return host.private_ip or host.ip_address or host.public_ip
+
+
+def _sanitize_label(value: Any) -> str:
+    """Prom label value 必须是字符串，None / 数字统一转 str，裁掉换行防 JSON 污染。"""
+    if value is None:
+        return ""
+    return str(value).replace("\n", " ").strip()
+
+
+def _target_from_host(host: Host) -> dict[str, Any] | None:
+    ip = _primary_ip(host)
+    if not ip:
+        return None
+    return {
+        "targets": [f"{ip}:{DEFAULT_NODE_EXPORTER_PORT}"],
+        "labels": {
+            "hostname": _sanitize_label(host.hostname),
+            "host_id": str(host.id),
+            "group": _sanitize_label(host.group_name) or "default",
+            "target_type": "host",
+            "os": _sanitize_label(host.os),
+            "arch": _sanitize_label(host.arch),
+            # 便于后续写 PromQL：status='online' | 'offline'
+            "nightmend_status": _sanitize_label(host.status),
+        },
+    }
+
+
+def _target_from_service(svc: Service) -> dict[str, Any] | None:
+    """从 service.target 推 host:port；URL 型取 netloc，host:port 型直接用。"""
+    raw = (svc.target or "").strip()
+    if not raw:
+        return None
+    host_port: str | None = None
+    if "://" in raw:
+        parsed = urlparse(raw)
+        if parsed.hostname:
+            port = parsed.port or (443 if parsed.scheme == "https" else 80)
+            host_port = f"{parsed.hostname}:{port}"
+    elif ":" in raw and "/" not in raw:
+        # "host:port" 裸格式
+        host_port = raw
+    if not host_port:
+        return None
+
+    return {
+        "targets": [host_port],
+        "labels": {
+            "service_name": _sanitize_label(svc.name),
+            "service_id": str(svc.id),
+            "service_type": _sanitize_label(svc.type),
+            "category": _sanitize_label(svc.category) or "business",
+            "target_type": "service",
+            # blackbox_exporter 用得上这个标签区分 module
+            "probe_module": "http_2xx" if svc.type == "http" else "tcp_connect",
+        },
+    }
+
+
+def build_host_targets(hosts: Iterable[Host]) -> list[dict[str, Any]]:
+    """纯函数：Host list → Prom file_sd 列表；None 项过滤。"""
+    out: list[dict[str, Any]] = []
+    for h in hosts:
+        t = _target_from_host(h)
+        if t is not None:
+            out.append(t)
+    return out
+
+
+def build_service_targets(services: Iterable[Service]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for s in services:
+        t = _target_from_service(s)
+        if t is not None:
+            out.append(t)
+    return out
+
+
+def _atomic_write_json(path: str, data: Any) -> None:
+    """原子写 JSON：tmp + rename 防止 Prom 读半截。"""
+    directory = os.path.dirname(path) or "."
+    Path(directory).mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".nightmend-sd-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+async def sync_file_sd(
+    db: AsyncSession,
+    *,
+    targets_dir: str | None = None,
+) -> dict[str, Any]:
+    """
+    全量导出 Host + Service 到 file_sd targets。
+
+    sidecar 未启用时短路；file_sd 依赖文件系统，不依赖 sidecar 可达。
+    """
+    if not settings.prometheus_remote_enabled:
+        return {"synced": False, "reason": "prometheus_remote_disabled"}
+
+    directory = targets_dir or DEFAULT_TARGETS_DIR
+
+    # 只导出已启用/在线的 Host + 监控开启的 Service，避免给 Prom 打脏目标
+    host_rows = (
+        await db.execute(select(Host).where(Host.status.in_(["online", "unknown"])))
+    ).scalars().all()
+    svc_rows = (
+        await db.execute(select(Service).where(Service.is_active.is_(True)))
+    ).scalars().all()
+
+    host_targets = build_host_targets(host_rows)
+    svc_targets = build_service_targets(svc_rows)
+
+    hosts_path = os.path.join(directory, "hosts.json")
+    services_path = os.path.join(directory, "services.json")
+    _atomic_write_json(hosts_path, host_targets)
+    _atomic_write_json(services_path, svc_targets)
+
+    logger.info(
+        "file_sd exported: dir=%s hosts=%d services=%d",
+        directory, len(host_targets), len(svc_targets),
+    )
+    return {
+        "synced": True,
+        "dir": directory,
+        "hosts_count": len(host_targets),
+        "services_count": len(svc_targets),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }

--- a/backend/app/services/prom_rules_sync.py
+++ b/backend/app/services/prom_rules_sync.py
@@ -1,0 +1,171 @@
+"""Prometheus rules.yml 同步器 (Prometheus rules.yml Synchronizer)
+
+职责 (Responsibilities):
+    - 从 AlertRule 表读取 query_expr 非空的规则，生成 Prometheus 规则文件
+    - 原子写入 /etc/prometheus/rules/nightmend.yml（写 tmp + rename）
+    - 触发 POST /-/reload 让 sidecar 热加载，无需重启
+    - 回填 prom_rule_synced_at 时间戳
+
+产出格式 (Output Format, Prometheus spec):
+    groups:
+      - name: nightmend_<rule_id>
+        rules:
+          - alert: <name>
+            expr: <query_expr>
+            for: <for_duration_seconds>s
+            labels:
+              severity: <severity>
+              nightmend_rule_id: "<id>"
+            annotations:
+              summary: <description>
+
+调用契机 (When to invoke):
+    - AlertRule 创建/更新/删除成功后（由 router 中的 hook 触发）
+    - 启动时幂等同步一次（lifespan 钩子可选加）
+"""
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+import yaml
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.alert import AlertRule
+
+logger = logging.getLogger(__name__)
+
+# 规则文件默认写入位置；docker compose 已把 ./prometheus/rules 挂到 /etc/prometheus/rules。
+# 允许通过 env 覆盖，方便开发机/测试跑非容器环境。
+DEFAULT_RULES_PATH = os.environ.get(
+    "NIGHTMEND_PROM_RULES_PATH",
+    "/etc/prometheus/rules/nightmend.yml",
+)
+
+
+def _rule_to_prom_dict(rule: AlertRule) -> dict[str, Any]:
+    """单条 AlertRule 转换为 Prometheus 规则 dict。"""
+    for_seconds = rule.for_duration_seconds or max(rule.duration_seconds or 0, 60)
+    labels: dict[str, str] = {
+        "severity": rule.severity or "warning",
+        "nightmend_rule_id": str(rule.id),
+    }
+    if rule.target_type:
+        labels["target_type"] = rule.target_type
+    annotations: dict[str, str] = {
+        "summary": rule.name or f"rule-{rule.id}",
+    }
+    if rule.description:
+        annotations["description"] = rule.description
+    return {
+        "alert": rule.name or f"nightmend_rule_{rule.id}",
+        "expr": rule.query_expr,
+        "for": f"{for_seconds}s",
+        "labels": labels,
+        "annotations": annotations,
+    }
+
+
+def _atomic_write(path: str, content: str) -> None:
+    """写 tmp 再 rename，避免 Prometheus 读到半截文件。"""
+    directory = os.path.dirname(path) or "."
+    Path(directory).mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".nightmend-rules-", suffix=".yml")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+async def _trigger_reload() -> bool:
+    """POST /-/reload；失败不抛，因 rules 文件已落盘，Prom 默认也会定期 load。"""
+    base = settings.prometheus_remote_url.rstrip("/")
+    try:
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            response = await client.post(f"{base}/-/reload")
+        if response.status_code == 200:
+            return True
+        logger.warning(
+            "Prometheus reload returned %s: %s", response.status_code, response.text[:200]
+        )
+        return False
+    except httpx.RequestError as exc:
+        logger.warning("Prometheus reload request failed: %s", exc)
+        return False
+
+
+def build_rules_yaml(rules: list[AlertRule]) -> str:
+    """纯函数：AlertRule 列表 → Prom rules.yml 字符串；便于测试。"""
+    # 每条 rule 自成一个 group，方便单条生效/失效不影响其他。
+    groups = [
+        {
+            "name": f"nightmend_{rule.id}",
+            "rules": [_rule_to_prom_dict(rule)],
+        }
+        for rule in rules
+        if rule.query_expr and rule.is_enabled
+    ]
+    payload = {"groups": groups}
+    return yaml.safe_dump(payload, sort_keys=False, allow_unicode=True)
+
+
+async def sync_rules_to_prometheus(
+    db: AsyncSession,
+    *,
+    rules_path: str | None = None,
+    reload_sidecar: bool = True,
+) -> dict[str, Any]:
+    """同步主入口。返回统计数据，便于 API 层回显。"""
+    if not settings.prometheus_remote_enabled:
+        # 未启用 sidecar 时不写文件，避免在不跑 Prom 的部署里留 artifact。
+        return {"synced": 0, "skipped": True, "reason": "prometheus_remote_disabled"}
+
+    path = rules_path or DEFAULT_RULES_PATH
+
+    result = await db.execute(
+        select(AlertRule).where(AlertRule.query_expr.isnot(None)).order_by(AlertRule.id)
+    )
+    rules = list(result.scalars().all())
+
+    content = build_rules_yaml(rules)
+    _atomic_write(path, content)
+
+    now = datetime.now(timezone.utc)
+    eligible_ids = [r.id for r in rules if r.query_expr and r.is_enabled]
+    if eligible_ids:
+        # 只标记实际写入规则的行，失效 / 空 expr 的记录不触碰
+        await db.execute(
+            AlertRule.__table__.update()
+            .where(AlertRule.id.in_(eligible_ids))
+            .values(prom_rule_synced_at=now)
+        )
+        await db.commit()
+
+    reloaded = False
+    if reload_sidecar:
+        reloaded = await _trigger_reload()
+
+    logger.info(
+        "Prometheus rules synced: path=%s rules=%d eligible=%d reloaded=%s",
+        path, len(rules), len(eligible_ids), reloaded,
+    )
+    return {
+        "synced": len(eligible_ids),
+        "total_with_expr": len(rules),
+        "path": path,
+        "reloaded": reloaded,
+        "skipped": False,
+    }

--- a/backend/app/services/prometheus_remote.py
+++ b/backend/app/services/prometheus_remote.py
@@ -1,0 +1,109 @@
+"""Prometheus sidecar 转发客户端 (Prometheus Sidecar Forwarding Client)
+
+底层逻辑：
+    当 settings.prometheus_remote_enabled=True 时，PromQL 查询从 NightMend 内置
+    mini 引擎（基于 HostMetric 表）切换到真正的 Prometheus sidecar HTTP API。
+    保持响应结构兼容既有 router 调用方，前端零感知。
+
+响应格式契约：
+    {
+        "resultType": "vector" | "matrix" | "scalar" | "string",
+        "result": [...],
+    }
+
+失败路径：
+    - sidecar 不可达：抛 PrometheusRemoteUnavailable，上层决定是否 fallback 或透传 500
+    - sidecar 返回 4xx/5xx：封装 message 抛出，保留上游错误链路
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class PrometheusRemoteUnavailable(RuntimeError):
+    """sidecar 网络不可达或 >=500 时抛出，调用方可决定 fallback 或 503。"""
+
+
+class PrometheusRemoteError(ValueError):
+    """sidecar 返回 status=error 或 4xx 时抛出，通常是用户 query 不合法。"""
+
+
+async def _request(
+    path: str,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    base = settings.prometheus_remote_url.rstrip("/")
+    url = f"{base}{path}"
+    timeout = settings.prometheus_remote_timeout_seconds
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(url, params=params)
+    except httpx.RequestError as exc:
+        # 连接级错误：DNS 失败、超时、TCP 重置
+        logger.warning("Prometheus sidecar unreachable: %s", exc)
+        raise PrometheusRemoteUnavailable(f"Prometheus sidecar unreachable: {exc}") from exc
+
+    if response.status_code >= 500:
+        raise PrometheusRemoteUnavailable(
+            f"Prometheus returned {response.status_code}: {response.text[:200]}"
+        )
+
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise PrometheusRemoteUnavailable(f"Prometheus returned non-JSON: {exc}") from exc
+
+    status = body.get("status")
+    if status == "error" or response.status_code >= 400:
+        error_type = body.get("errorType", "execution")
+        error_msg = body.get("error", response.text[:200])
+        raise PrometheusRemoteError(f"{error_type}: {error_msg}")
+
+    data = body.get("data")
+    if not isinstance(data, dict):
+        raise PrometheusRemoteUnavailable("Prometheus response missing data field")
+    return data
+
+
+async def instant_query(query: str, eval_time: datetime | None = None) -> dict[str, Any]:
+    """转发 /api/v1/query 到 sidecar。返回 Prometheus data 对象。"""
+    params: dict[str, Any] = {"query": query}
+    if eval_time is not None:
+        params["time"] = eval_time.timestamp()
+    return await _request("/api/v1/query", params)
+
+
+async def range_query(
+    query: str,
+    start: datetime,
+    end: datetime,
+    step: timedelta,
+) -> dict[str, Any]:
+    """转发 /api/v1/query_range 到 sidecar。"""
+    params = {
+        "query": query,
+        "start": start.timestamp(),
+        "end": end.timestamp(),
+        # Prometheus 接受数字秒或 duration 字符串，数字更安全
+        "step": step.total_seconds(),
+    }
+    return await _request("/api/v1/query_range", params)
+
+
+async def is_healthy() -> bool:
+    """用于启动期/健康检查；/-/healthy 200 即视为可用。"""
+    base = settings.prometheus_remote_url.rstrip("/")
+    try:
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            response = await client.get(f"{base}/-/healthy")
+        return response.status_code == 200
+    except httpx.RequestError:
+        return False

--- a/backend/app/services/promql_service.py
+++ b/backend/app/services/promql_service.py
@@ -28,8 +28,10 @@ from typing import Any, Optional
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.models.host_metric import HostMetric
 from app.models.host import Host
+from app.services import prometheus_remote
 
 logger = logging.getLogger(__name__)
 
@@ -450,6 +452,17 @@ async def execute_instant_query(
     Raises:
         ValueError: 查询解析或执行失败 (Query parse or execution failure)
     """
+    # ── Prometheus sidecar 分发 (Prometheus sidecar dispatch) ───────────────
+    # 开关开启时优先走 sidecar；不可达则 fallback 到内置引擎，保持可用性。
+    if settings.prometheus_remote_enabled:
+        try:
+            return await prometheus_remote.instant_query(expr, eval_time)
+        except prometheus_remote.PrometheusRemoteError:
+            # 用户 query 非法：透传 ValueError 让 router 返回 400
+            raise
+        except prometheus_remote.PrometheusRemoteUnavailable as exc:
+            logger.warning("Prometheus sidecar unavailable, falling back to local engine: %s", exc)
+
     pq = parse_promql(expr)
     if eval_time is None:
         eval_time = datetime.now(timezone.utc)
@@ -703,6 +716,15 @@ async def execute_range_query(
     Raises:
         ValueError: 查询解析或执行失败 (Query parse or execution failure)
     """
+    # ── Prometheus sidecar 分发 (Prometheus sidecar dispatch) ───────────────
+    if settings.prometheus_remote_enabled:
+        try:
+            return await prometheus_remote.range_query(expr, start, end, step)
+        except prometheus_remote.PrometheusRemoteError:
+            raise
+        except prometheus_remote.PrometheusRemoteUnavailable as exc:
+            logger.warning("Prometheus sidecar unavailable, falling back to local engine: %s", exc)
+
     pq = parse_promql(expr)
 
     # 范围向量函数的特殊处理 (Special handling for range vector functions)

--- a/backend/app/tasks/prom_file_sd_task.py
+++ b/backend/app/tasks/prom_file_sd_task.py
@@ -1,0 +1,30 @@
+"""Prometheus file_sd 后台同步任务。
+
+每 SYNC_INTERVAL 秒把 Host / Service 表导出到 targets 目录。
+Host 新增/下线只要在下次刷新窗口内即可被 sidecar 感知，无需重启。
+
+任务注册：由 main.py lifespan 按 PROMETHEUS_REMOTE_ENABLED 条件启动。
+"""
+import asyncio
+import logging
+
+from app.core.config import settings
+from app.core.database import async_session
+from app.services.prom_file_sd import sync_file_sd
+
+logger = logging.getLogger(__name__)
+
+SYNC_INTERVAL = 60  # 秒；Prom file_sd refresh_interval 是 30s，导出 60s 就能覆盖
+
+
+async def prom_file_sd_loop() -> None:
+    """Loop 本体；异常不上抛，任务 monitor 会用 30s 健康检查兜底。"""
+    logger.info("Prometheus file_sd sync task started (interval=%ss)", SYNC_INTERVAL)
+    while True:
+        try:
+            if settings.prometheus_remote_enabled:
+                async with async_session() as db:
+                    await sync_file_sd(db)
+        except Exception:
+            logger.exception("Error syncing Prometheus file_sd targets")
+        await asyncio.sleep(SYNC_INTERVAL)

--- a/backend/tests/test_prom_file_sd.py
+++ b/backend/tests/test_prom_file_sd.py
@@ -1,0 +1,217 @@
+"""Prometheus file_sd 导出器单元测试。
+
+覆盖点：
+  - _target_from_host: IP 优先级 private > ip_address > public；缺失返回 None
+  - _target_from_service: 支持 http://url / host:port 两种格式；URL 端口推断
+  - build_*_targets 纯函数过滤 None
+  - 原子写 JSON 覆盖、tmp 清理
+  - sync_file_sd flag=off 短路
+  - sync_file_sd 写 hosts.json + services.json 并统计正确
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.core.config import settings
+from app.models.host import Host
+from app.models.service import Service
+from app.services import prom_file_sd
+
+
+def _host(**kwargs) -> Host:
+    h = Host()
+    h.id = kwargs.get("id", 1)
+    h.hostname = kwargs.get("hostname", "web-01")
+    h.display_name = kwargs.get("display_name")
+    h.ip_address = kwargs.get("ip_address")
+    h.private_ip = kwargs.get("private_ip")
+    h.public_ip = kwargs.get("public_ip")
+    h.os = kwargs.get("os", "linux")
+    h.os_version = kwargs.get("os_version")
+    h.arch = kwargs.get("arch", "x86_64")
+    h.cpu_cores = kwargs.get("cpu_cores")
+    h.memory_total_mb = kwargs.get("memory_total_mb")
+    h.agent_version = kwargs.get("agent_version")
+    h.status = kwargs.get("status", "online")
+    h.tags = kwargs.get("tags") or {}
+    h.group_name = kwargs.get("group_name")
+    h.network_info = kwargs.get("network_info")
+    h.agent_token_id = kwargs.get("agent_token_id", 1)
+    h.last_heartbeat = kwargs.get("last_heartbeat")
+    return h
+
+
+def _svc(**kwargs) -> Service:
+    s = Service()
+    s.id = kwargs.get("id", 1)
+    s.name = kwargs.get("name", "api")
+    s.type = kwargs.get("type", "http")
+    s.target = kwargs.get("target", "http://example.com/health")
+    s.check_interval = kwargs.get("check_interval", 60)
+    s.timeout = kwargs.get("timeout", 10)
+    s.expected_status = kwargs.get("expected_status")
+    s.is_active = kwargs.get("is_active", True)
+    s.status = kwargs.get("status", "up")
+    s.host_id = kwargs.get("host_id")
+    s.category = kwargs.get("category", "business")
+    s.tags = kwargs.get("tags")
+    return s
+
+
+# ─── 纯函数测试 ──────────────────────────────────────────────────────────
+
+
+def test_host_ip_priority_private_wins():
+    h = _host(private_ip="10.0.0.1", ip_address="192.168.1.1", public_ip="1.2.3.4")
+    t = prom_file_sd._target_from_host(h)
+    assert t["targets"] == ["10.0.0.1:9100"]
+
+
+def test_host_ip_fallback_public_last():
+    h = _host(private_ip=None, ip_address=None, public_ip="1.2.3.4")
+    t = prom_file_sd._target_from_host(h)
+    assert t["targets"] == ["1.2.3.4:9100"]
+
+
+def test_host_no_ip_returns_none():
+    h = _host(private_ip=None, ip_address=None, public_ip=None)
+    assert prom_file_sd._target_from_host(h) is None
+
+
+def test_host_labels_include_hostname_group_status():
+    h = _host(hostname="web-01", private_ip="10.0.0.1", group_name="prod", status="online", os="linux", arch="arm64")
+    t = prom_file_sd._target_from_host(h)
+    labels = t["labels"]
+    assert labels["hostname"] == "web-01"
+    assert labels["group"] == "prod"
+    assert labels["nightmend_status"] == "online"
+    assert labels["target_type"] == "host"
+    assert labels["os"] == "linux"
+    assert labels["arch"] == "arm64"
+
+
+def test_host_group_default_when_empty():
+    h = _host(private_ip="10.0.0.1", group_name=None)
+    t = prom_file_sd._target_from_host(h)
+    assert t["labels"]["group"] == "default"
+
+
+def test_service_url_target_parses_port():
+    s = _svc(type="http", target="https://api.example.com/health")
+    t = prom_file_sd._target_from_service(s)
+    assert t["targets"] == ["api.example.com:443"]
+    assert t["labels"]["probe_module"] == "http_2xx"
+
+
+def test_service_url_http_default_port_80():
+    s = _svc(type="http", target="http://api.example.com/")
+    t = prom_file_sd._target_from_service(s)
+    assert t["targets"] == ["api.example.com:80"]
+
+
+def test_service_url_explicit_port():
+    s = _svc(type="http", target="http://api.example.com:8080/ping")
+    t = prom_file_sd._target_from_service(s)
+    assert t["targets"] == ["api.example.com:8080"]
+
+
+def test_service_plain_host_port():
+    s = _svc(type="tcp", target="db-01.internal:5432")
+    t = prom_file_sd._target_from_service(s)
+    assert t["targets"] == ["db-01.internal:5432"]
+    assert t["labels"]["probe_module"] == "tcp_connect"
+    assert t["labels"]["service_type"] == "tcp"
+
+
+def test_service_bad_target_returns_none():
+    assert prom_file_sd._target_from_service(_svc(target="")) is None
+    assert prom_file_sd._target_from_service(_svc(target="/healthz")) is None
+
+
+def test_build_host_targets_filters_unmatched():
+    hosts = [_host(private_ip="10.0.0.1"), _host(private_ip=None, ip_address=None, public_ip=None)]
+    result = prom_file_sd.build_host_targets(hosts)
+    assert len(result) == 1
+
+
+def test_build_service_targets_filters_unmatched():
+    svcs = [_svc(target="http://ok.example.com/"), _svc(target="???")]
+    result = prom_file_sd.build_service_targets(svcs)
+    assert len(result) == 1
+
+
+# ─── 原子写测试 ──────────────────────────────────────────────────────────
+
+
+def test_atomic_write_json_round_trip(tmp_path):
+    target = tmp_path / "sub" / "hosts.json"
+    data = [{"targets": ["10.0.0.1:9100"], "labels": {"hostname": "h1"}}]
+    prom_file_sd._atomic_write_json(str(target), data)
+    assert json.loads(target.read_text()) == data
+    # overwrite
+    prom_file_sd._atomic_write_json(str(target), [])
+    assert json.loads(target.read_text()) == []
+    # 无 .nightmend-sd- 残留
+    leftover = [p for p in target.parent.iterdir() if p.name.startswith(".nightmend-sd-")]
+    assert leftover == []
+
+
+# ─── sync 主入口 ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sync_file_sd_skipped_when_flag_disabled(tmp_path):
+    with patch.object(settings, "prometheus_remote_enabled", False):
+        result = await prom_file_sd.sync_file_sd(db=None, targets_dir=str(tmp_path))
+    assert result["synced"] is False
+    assert result["reason"] == "prometheus_remote_disabled"
+    assert not (tmp_path / "hosts.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_sync_file_sd_writes_both_files(tmp_path):
+    hosts = [_host(id=1, private_ip="10.0.0.1"), _host(id=2, private_ip="10.0.0.2")]
+    svcs = [_svc(id=10, target="http://ok.example.com/")]
+
+    class _FakeScalars:
+        def __init__(self, items):
+            self._items = items
+
+        def all(self):
+            return self._items
+
+    class _FakeResult:
+        def __init__(self, items):
+            self._items = items
+
+        def scalars(self):
+            return _FakeScalars(self._items)
+
+    calls: list = []
+
+    async def _execute(stmt):
+        # 第一次 query Host，第二次 query Service
+        if len(calls) == 0:
+            calls.append("host")
+            return _FakeResult(hosts)
+        calls.append("service")
+        return _FakeResult(svcs)
+
+    fake_db = AsyncMock()
+    fake_db.execute = AsyncMock(side_effect=_execute)
+
+    with patch.object(settings, "prometheus_remote_enabled", True):
+        result = await prom_file_sd.sync_file_sd(db=fake_db, targets_dir=str(tmp_path))
+
+    assert result["synced"] is True
+    assert result["hosts_count"] == 2
+    assert result["services_count"] == 1
+    hosts_data = json.loads((tmp_path / "hosts.json").read_text())
+    svcs_data = json.loads((tmp_path / "services.json").read_text())
+    assert len(hosts_data) == 2
+    assert len(svcs_data) == 1
+    assert hosts_data[0]["labels"]["target_type"] == "host"
+    assert svcs_data[0]["labels"]["target_type"] == "service"

--- a/backend/tests/test_prom_remote_write.py
+++ b/backend/tests/test_prom_remote_write.py
@@ -1,0 +1,204 @@
+"""Prometheus Remote Write 接收器测试。
+
+覆盖：
+  - 禁用 flag → 503
+  - 无鉴权 → 401
+  - token 不匹配 → 401
+  - token 未配置但客户端发 Bearer → 503
+  - body 超限 → 413
+  - 空 body → 400
+  - 正常流程 → 204，sidecar 收到原样 bytes + 白名单头
+  - sidecar 4xx → 透传；sidecar 5xx → 502；sidecar 连接失败 → 502
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from app.core.config import settings
+
+
+VALID_TOKEN = "test-rw-token-0123"
+
+
+class _UpstreamResp:
+    def __init__(self, status_code: int, text: str = "ok"):
+        self.status_code = status_code
+        self.text = text
+
+
+class _UpstreamClient:
+    """Mock httpx.AsyncClient 捕获 forward 调用。"""
+
+    def __init__(self, response=None, exc=None, captured: dict | None = None):
+        self._response = response
+        self._exc = exc
+        self._captured = captured if captured is not None else {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def post(self, url, content=None, headers=None):
+        self._captured["url"] = url
+        self._captured["content"] = content
+        self._captured["headers"] = headers
+        if self._exc is not None:
+            raise self._exc
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_disabled_when_flag_off(client):
+    with patch.object(settings, "prometheus_remote_enabled", False):
+        response = await client.post(
+            "/api/v1/prom/remote_write",
+            headers={"authorization": f"Bearer {VALID_TOKEN}"},
+            content=b"payload",
+        )
+    assert response.status_code == 503
+    assert "PROMETHEUS_REMOTE_ENABLED" in response.text
+
+
+@pytest.mark.asyncio
+async def test_missing_auth_returns_401(client):
+    with patch.object(settings, "prometheus_remote_enabled", True), \
+         patch.object(settings, "prom_remote_write_token", VALID_TOKEN):
+        response = await client.post("/api/v1/prom/remote_write", content=b"x")
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_wrong_bearer_returns_401(client):
+    with patch.object(settings, "prometheus_remote_enabled", True), \
+         patch.object(settings, "prom_remote_write_token", VALID_TOKEN):
+        response = await client.post(
+            "/api/v1/prom/remote_write",
+            headers={"authorization": "Bearer wrong-token"},
+            content=b"x",
+        )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_bearer_sent_but_token_unconfigured_returns_503(client):
+    with patch.object(settings, "prometheus_remote_enabled", True), \
+         patch.object(settings, "prom_remote_write_token", ""):
+        response = await client.post(
+            "/api/v1/prom/remote_write",
+            headers={"authorization": "Bearer anything"},
+            content=b"x",
+        )
+    assert response.status_code == 503
+    assert "Remote write token" in response.text
+
+
+@pytest.mark.asyncio
+async def test_empty_body_returns_400(client):
+    with patch.object(settings, "prometheus_remote_enabled", True), \
+         patch.object(settings, "prom_remote_write_token", VALID_TOKEN):
+        response = await client.post(
+            "/api/v1/prom/remote_write",
+            headers={"authorization": f"Bearer {VALID_TOKEN}"},
+            content=b"",
+        )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_body_too_large_returns_413(client):
+    # 11 MB > 10 MB 上限
+    big_body = b"\x00" * (11 * 1024 * 1024)
+    with patch.object(settings, "prometheus_remote_enabled", True), \
+         patch.object(settings, "prom_remote_write_token", VALID_TOKEN):
+        response = await client.post(
+            "/api/v1/prom/remote_write",
+            headers={"authorization": f"Bearer {VALID_TOKEN}"},
+            content=big_body,
+        )
+    assert response.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_happy_path_forwards_to_sidecar_and_returns_204(client):
+    captured: dict = {}
+    upstream = _UpstreamClient(response=_UpstreamResp(204), captured=captured)
+
+    # Prom 客户端会带 Content-Encoding 和 Content-Type，验证白名单通过
+    send_body = b"fake-snappy-bytes"
+    send_headers = {
+        "authorization": f"Bearer {VALID_TOKEN}",
+        "content-encoding": "snappy",
+        "content-type": "application/x-protobuf",
+        "x-prometheus-remote-write-version": "0.1.0",
+        "cookie": "access_token=should-not-forward",  # 敏感头必须过滤
+    }
+    with patch.object(settings, "prometheus_remote_enabled", True), \
+         patch.object(settings, "prom_remote_write_token", VALID_TOKEN), \
+         patch.object(settings, "prometheus_remote_url", "http://prometheus:9090"), \
+         patch("app.routers.prom_remote_write.httpx.AsyncClient", return_value=upstream):
+        response = await client.post(
+            "/api/v1/prom/remote_write",
+            headers=send_headers,
+            content=send_body,
+        )
+
+    assert response.status_code == 204
+    # 原样 bytes 转发
+    assert captured["content"] == send_body
+    assert captured["url"] == "http://prometheus:9090/api/v1/write"
+    fwd = {k.lower(): v for k, v in captured["headers"].items()}
+    # 协议头透传
+    assert fwd["content-encoding"] == "snappy"
+    assert fwd["content-type"] == "application/x-protobuf"
+    assert fwd["x-prometheus-remote-write-version"] == "0.1.0"
+    # cookie/authorization 不能泄给 Prom
+    assert "cookie" not in fwd
+    assert "authorization" not in fwd
+
+
+@pytest.mark.asyncio
+async def test_sidecar_connection_error_returns_502(client):
+    upstream = _UpstreamClient(exc=httpx.ConnectError("dns fail"))
+    with patch.object(settings, "prometheus_remote_enabled", True), \
+         patch.object(settings, "prom_remote_write_token", VALID_TOKEN), \
+         patch("app.routers.prom_remote_write.httpx.AsyncClient", return_value=upstream):
+        response = await client.post(
+            "/api/v1/prom/remote_write",
+            headers={"authorization": f"Bearer {VALID_TOKEN}"},
+            content=b"payload",
+        )
+    assert response.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_sidecar_4xx_passes_through(client):
+    upstream = _UpstreamClient(response=_UpstreamResp(400, text="bad samples"))
+    with patch.object(settings, "prometheus_remote_enabled", True), \
+         patch.object(settings, "prom_remote_write_token", VALID_TOKEN), \
+         patch("app.routers.prom_remote_write.httpx.AsyncClient", return_value=upstream):
+        response = await client.post(
+            "/api/v1/prom/remote_write",
+            headers={"authorization": f"Bearer {VALID_TOKEN}"},
+            content=b"payload",
+        )
+    assert response.status_code == 400
+    assert "bad samples" in response.text
+
+
+@pytest.mark.asyncio
+async def test_sidecar_5xx_becomes_502(client):
+    upstream = _UpstreamClient(response=_UpstreamResp(500, text="boom"))
+    with patch.object(settings, "prometheus_remote_enabled", True), \
+         patch.object(settings, "prom_remote_write_token", VALID_TOKEN), \
+         patch("app.routers.prom_remote_write.httpx.AsyncClient", return_value=upstream):
+        response = await client.post(
+            "/api/v1/prom/remote_write",
+            headers={"authorization": f"Bearer {VALID_TOKEN}"},
+            content=b"payload",
+        )
+    assert response.status_code == 502

--- a/backend/tests/test_prom_rules_sync.py
+++ b/backend/tests/test_prom_rules_sync.py
@@ -1,0 +1,221 @@
+"""Prometheus rules.yml 同步器单元测试。
+
+覆盖点：
+  - build_rules_yaml 纯函数：只取 query_expr 非空 + is_enabled，输出 Prom 规范结构
+  - _atomic_write 真写文件、覆写安全
+  - sync_rules_to_prometheus 在 flag=off 时跳过
+  - flag=on 时写入 + 触发 reload + 回填 prom_rule_synced_at
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import yaml
+
+from app.core.config import settings
+from app.models.alert import AlertRule
+from app.services import prom_rules_sync
+
+
+def _make_rule(**kwargs) -> AlertRule:
+    """构造一条 in-memory AlertRule，不触碰 DB。"""
+    defaults = dict(
+        id=1,
+        name="high_5xx",
+        description="too many server errors",
+        severity="critical",
+        metric="http_5xx",
+        operator=">",
+        threshold=0.1,
+        duration_seconds=60,
+        is_builtin=False,
+        is_enabled=True,
+        target_type="host",
+        target_filter=None,
+        rule_type="metric",
+        cooldown_seconds=300,
+        continuous_alert=True,
+        query_expr='rate(http_requests_total{status=~"5.."}[5m]) > 0.1',
+        for_duration_seconds=120,
+        prom_rule_synced_at=None,
+    )
+    defaults.update(kwargs)
+    rule = AlertRule()
+    for k, v in defaults.items():
+        setattr(rule, k, v)
+    return rule
+
+
+# ─── 纯函数测试 ───────────────────────────────────────────────────────────────
+
+
+def test_build_rules_yaml_shape():
+    rules = [_make_rule(id=1), _make_rule(id=2, name="rule2")]
+    out = prom_rules_sync.build_rules_yaml(rules)
+    parsed = yaml.safe_load(out)
+    assert isinstance(parsed["groups"], list)
+    assert len(parsed["groups"]) == 2
+    g = parsed["groups"][0]
+    assert g["name"] == "nightmend_1"
+    assert g["rules"][0]["alert"] == "high_5xx"
+    assert g["rules"][0]["expr"].startswith("rate(")
+    assert g["rules"][0]["for"] == "120s"
+    assert g["rules"][0]["labels"]["severity"] == "critical"
+    assert g["rules"][0]["labels"]["nightmend_rule_id"] == "1"
+    assert "summary" in g["rules"][0]["annotations"]
+
+
+def test_build_rules_yaml_skips_disabled_or_missing_expr():
+    rules = [
+        _make_rule(id=1, is_enabled=False),                # 停用 → 跳过
+        _make_rule(id=2, query_expr=None),                  # 无 expr → 跳过（老 metric 规则）
+        _make_rule(id=3, name="keep_me"),                   # 留下
+    ]
+    parsed = yaml.safe_load(prom_rules_sync.build_rules_yaml(rules))
+    assert len(parsed["groups"]) == 1
+    assert parsed["groups"][0]["name"] == "nightmend_3"
+
+
+def test_build_rules_yaml_falls_back_to_duration_when_for_missing():
+    r = _make_rule(for_duration_seconds=None, duration_seconds=180)
+    parsed = yaml.safe_load(prom_rules_sync.build_rules_yaml([r]))
+    assert parsed["groups"][0]["rules"][0]["for"] == "180s"
+
+
+def test_build_rules_yaml_minimum_for_60s_when_duration_tiny():
+    """duration=0 时至少给 60s，避免 Prometheus 抛空/负值错误。"""
+    r = _make_rule(for_duration_seconds=None, duration_seconds=0)
+    parsed = yaml.safe_load(prom_rules_sync.build_rules_yaml([r]))
+    assert parsed["groups"][0]["rules"][0]["for"] == "60s"
+
+
+# ─── 原子写测试 ──────────────────────────────────────────────────────────────
+
+
+def test_atomic_write_creates_and_overwrites(tmp_path):
+    target = tmp_path / "sub" / "rules.yml"
+    prom_rules_sync._atomic_write(str(target), "groups: []\n")
+    assert target.read_text() == "groups: []\n"
+    prom_rules_sync._atomic_write(str(target), "groups:\n  - name: x\n")
+    assert "name: x" in target.read_text()
+    # 无 tmp 残留
+    tmp_siblings = [p for p in target.parent.iterdir() if p.name.startswith(".nightmend-rules-")]
+    assert tmp_siblings == []
+
+
+# ─── sync 主入口（不走真实 DB） ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sync_skipped_when_flag_disabled(tmp_path):
+    target = tmp_path / "rules.yml"
+    with patch.object(settings, "prometheus_remote_enabled", False):
+        result = await prom_rules_sync.sync_rules_to_prometheus(
+            db=None,  # 不会用到
+            rules_path=str(target),
+        )
+    assert result["skipped"] is True
+    assert result["reason"] == "prometheus_remote_disabled"
+    assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_sync_writes_file_and_triggers_reload(tmp_path):
+    target = tmp_path / "rules.yml"
+    rule = _make_rule(id=42)
+
+    class _FakeScalars:
+        def __init__(self, items):
+            self._items = items
+
+        def all(self):
+            return self._items
+
+    class _FakeResult:
+        def __init__(self, items):
+            self._items = items
+
+        def scalars(self):
+            return _FakeScalars(self._items)
+
+    async def _fake_execute(stmt):
+        # 第一次是 select，第二次是 update；我们只关心第一次返回
+        return _FakeResult([rule])
+
+    fake_db = AsyncMock()
+    fake_db.execute = AsyncMock(side_effect=_fake_execute)
+    fake_db.commit = AsyncMock()
+
+    # httpx post 返回 200
+    class _Resp:
+        status_code = 200
+        text = "ok"
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, url):
+            return _Resp()
+
+    with patch.object(settings, "prometheus_remote_enabled", True), \
+         patch("app.services.prom_rules_sync.httpx.AsyncClient", return_value=_Client()):
+        result = await prom_rules_sync.sync_rules_to_prometheus(
+            db=fake_db,
+            rules_path=str(target),
+            reload_sidecar=True,
+        )
+
+    assert target.exists()
+    content = yaml.safe_load(target.read_text())
+    assert content["groups"][0]["name"] == "nightmend_42"
+    assert result["synced"] == 1
+    assert result["reloaded"] is True
+    fake_db.commit.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sync_survives_reload_failure(tmp_path):
+    """reload 调用失败不能让 sync 抛异常——文件已落盘即视为半成功。"""
+    target = tmp_path / "rules.yml"
+    rule = _make_rule()
+
+    class _FakeScalars:
+        def all(self):
+            return [rule]
+
+    class _FakeResult:
+        def scalars(self):
+            return _FakeScalars()
+
+    fake_db = AsyncMock()
+    fake_db.execute = AsyncMock(return_value=_FakeResult())
+    fake_db.commit = AsyncMock()
+
+    import httpx
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, url):
+            raise httpx.ConnectError("dns fail")
+
+    with patch.object(settings, "prometheus_remote_enabled", True), \
+         patch("app.services.prom_rules_sync.httpx.AsyncClient", return_value=_Client()):
+        result = await prom_rules_sync.sync_rules_to_prometheus(
+            db=fake_db,
+            rules_path=str(target),
+            reload_sidecar=True,
+        )
+
+    assert target.exists()
+    assert result["reloaded"] is False
+    assert result["synced"] == 1

--- a/backend/tests/test_prometheus_remote.py
+++ b/backend/tests/test_prometheus_remote.py
@@ -1,0 +1,182 @@
+"""Prometheus sidecar 转发客户端 + promql_service 分发行为测试。
+
+覆盖点：
+  1. sidecar 成功：返回 Prometheus data 对象
+  2. sidecar 4xx / status=error：抛 PrometheusRemoteError → 对应 400
+  3. sidecar 不可达：抛 PrometheusRemoteUnavailable → promql_service 降级到本地引擎
+  4. feature flag off：不访问 sidecar，直接走本地引擎
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.core.config import settings
+from app.services import prometheus_remote
+
+
+# ─── prometheus_remote 客户端单元测试 ──────────────────────────────────────────
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, body: dict | str):
+        self.status_code = status_code
+        self._body = body
+        self.text = body if isinstance(body, str) else ""
+
+    def json(self):
+        if isinstance(self._body, str):
+            raise ValueError("not json")
+        return self._body
+
+
+class _FakeClient:
+    """上下文管理器 mock，模拟 httpx.AsyncClient。"""
+
+    def __init__(self, response=None, exc=None):
+        self._response = response
+        self._exc = exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def get(self, url, params=None):
+        if self._exc is not None:
+            raise self._exc
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_instant_query_success():
+    resp = _FakeResponse(
+        200,
+        {"status": "success", "data": {"resultType": "vector", "result": [{"metric": {}, "value": [1.0, "42"]}]}},
+    )
+    with patch("app.services.prometheus_remote.httpx.AsyncClient", return_value=_FakeClient(response=resp)):
+        data = await prometheus_remote.instant_query("up")
+    assert data["resultType"] == "vector"
+    assert data["result"][0]["value"] == [1.0, "42"]
+
+
+@pytest.mark.asyncio
+async def test_instant_query_user_error_raises_remote_error():
+    resp = _FakeResponse(
+        400,
+        {"status": "error", "errorType": "bad_data", "error": "invalid expression"},
+    )
+    with patch("app.services.prometheus_remote.httpx.AsyncClient", return_value=_FakeClient(response=resp)):
+        with pytest.raises(prometheus_remote.PrometheusRemoteError) as exc_info:
+            await prometheus_remote.instant_query("bad!!!query")
+    assert "invalid expression" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_instant_query_server_error_raises_unavailable():
+    resp = _FakeResponse(503, "service unavailable")
+    with patch("app.services.prometheus_remote.httpx.AsyncClient", return_value=_FakeClient(response=resp)):
+        with pytest.raises(prometheus_remote.PrometheusRemoteUnavailable):
+            await prometheus_remote.instant_query("up")
+
+
+@pytest.mark.asyncio
+async def test_instant_query_connection_error_raises_unavailable():
+    fake_client = _FakeClient(exc=httpx.ConnectError("dns fail"))
+    with patch("app.services.prometheus_remote.httpx.AsyncClient", return_value=fake_client):
+        with pytest.raises(prometheus_remote.PrometheusRemoteUnavailable):
+            await prometheus_remote.instant_query("up")
+
+
+@pytest.mark.asyncio
+async def test_range_query_passes_correct_params():
+    resp = _FakeResponse(200, {"status": "success", "data": {"resultType": "matrix", "result": []}})
+    captured: dict = {}
+
+    class _CaptureClient(_FakeClient):
+        async def get(self, url, params=None):
+            captured["url"] = url
+            captured["params"] = params
+            return resp
+
+    with patch("app.services.prometheus_remote.httpx.AsyncClient", return_value=_CaptureClient(response=resp)):
+        start = datetime(2026, 4, 21, 0, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 4, 21, 1, 0, 0, tzinfo=timezone.utc)
+        step = timedelta(seconds=60)
+        await prometheus_remote.range_query("up", start, end, step)
+
+    assert captured["url"].endswith("/api/v1/query_range")
+    assert captured["params"]["query"] == "up"
+    assert captured["params"]["start"] == start.timestamp()
+    assert captured["params"]["end"] == end.timestamp()
+    assert captured["params"]["step"] == 60.0
+
+
+# ─── promql_service 分发行为测试 ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_promql_service_dispatches_to_sidecar_when_enabled():
+    """feature flag 开启 → 调用 sidecar，不触碰 HostMetric 本地引擎。"""
+    from app.services import promql_service
+
+    mock_result = {"resultType": "vector", "result": [{"metric": {"job": "nightmend"}, "value": [1.0, "3.14"]}]}
+    with patch.object(settings, "prometheus_remote_enabled", True), \
+         patch.object(prometheus_remote, "instant_query", new=AsyncMock(return_value=mock_result)) as m:
+        data = await promql_service.execute_instant_query(db=None, expr="up")  # db 不会被用到
+    assert data == mock_result
+    m.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_promql_service_fallback_when_sidecar_unavailable():
+    """sidecar 不可达 → 降级到本地引擎（走 parse_promql 路径）。"""
+    from app.services import promql_service
+
+    async def _raise_unavailable(*args, **kwargs):
+        raise prometheus_remote.PrometheusRemoteUnavailable("network down")
+
+    with patch.object(settings, "prometheus_remote_enabled", True), \
+         patch.object(prometheus_remote, "instant_query", new=_raise_unavailable), \
+         patch.object(promql_service, "parse_promql", side_effect=ValueError("fallback reached")):
+        with pytest.raises(ValueError, match="fallback reached"):
+            await promql_service.execute_instant_query(db=None, expr="up")
+
+
+@pytest.mark.asyncio
+async def test_promql_service_user_error_from_sidecar_raises_valueerror():
+    """sidecar 回 4xx → PrometheusRemoteError，为 ValueError 子类，router 会转 400。"""
+    from app.services import promql_service
+
+    async def _raise_user_err(*args, **kwargs):
+        raise prometheus_remote.PrometheusRemoteError("bad query")
+
+    with patch.object(settings, "prometheus_remote_enabled", True), \
+         patch.object(prometheus_remote, "instant_query", new=_raise_user_err):
+        with pytest.raises(ValueError):  # PrometheusRemoteError 继承自 ValueError
+            await promql_service.execute_instant_query(db=None, expr="bad!!!")
+
+
+@pytest.mark.asyncio
+async def test_promql_service_flag_off_does_not_call_sidecar():
+    """flag off → 根本不调 sidecar；走本地引擎。"""
+    from app.services import promql_service
+
+    sidecar_called = False
+
+    async def _spy(*args, **kwargs):
+        nonlocal sidecar_called
+        sidecar_called = True
+        return {}
+
+    with patch.object(settings, "prometheus_remote_enabled", False), \
+         patch.object(prometheus_remote, "instant_query", new=_spy), \
+         patch.object(promql_service, "parse_promql", side_effect=ValueError("local reached")):
+        with pytest.raises(ValueError, match="local reached"):
+            await promql_service.execute_instant_query(db=None, expr="up")
+
+    assert sidecar_called is False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,35 @@ services:
     profiles:
       - clickhouse
 
+  # Prometheus sidecar — NightMend 的 TSDB + PromQL 引擎后端 (可选)
+  # 启用方式: docker compose --profile prometheus up -d
+  # 开启后，backend 若设置 PROMETHEUS_REMOTE_ENABLED=true，promql 查询会转发到这里。
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    environment:
+      TZ: Asia/Shanghai
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=${PROMETHEUS_RETENTION:-30d}
+      - --web.enable-lifecycle         # 支持 POST /-/reload 热加载规则
+      - --web.listen-address=:9090
+    ports:
+      - "127.0.0.1:${PROMETHEUS_PORT:-9090}:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/rules:/etc/prometheus/rules:ro
+      - ./prometheus/targets:/etc/prometheus/targets:ro
+      - prometheusdata:/prometheus
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/healthy"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    profiles:
+      - prometheus
+
   # Grafana Loki 日志聚合 (Grafana Loki Log Aggregation) - 可选
   loki:
     image: grafana/loki:2.9.0
@@ -137,3 +166,4 @@ volumes:
   redisdata:
   clickhousedata:
   lokidata:
+  prometheusdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,8 @@ services:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus
       - --storage.tsdb.retention.time=${PROMETHEUS_RETENTION:-30d}
-      - --web.enable-lifecycle         # 支持 POST /-/reload 热加载规则
+      - --web.enable-lifecycle                    # 支持 POST /-/reload 热加载规则
+      - --web.enable-remote-write-receiver        # 允许外部 Prom push 数据进来
       - --web.listen-address=:9090
     ports:
       - "127.0.0.1:${PROMETHEUS_PORT:-9090}:9090"

--- a/frontend/src/components/PromQLRuleEditor.tsx
+++ b/frontend/src/components/PromQLRuleEditor.tsx
@@ -1,0 +1,219 @@
+/**
+ * PromQL 告警规则编辑器
+ *
+ * 与既有 metric+threshold 表单并列，用于为 AlertRule 填写 query_expr 与 for_duration_seconds。
+ *
+ * 交互：
+ *   - 600ms debounce 自动校验表达式（/api/v1/promql/query 跑 instant query）
+ *   - 手动"立即校验"按钮
+ *   - 示例下拉（常用 PromQL 片段），点击直接填入
+ *   - 校验成功展示 result type + 首行 series 预览
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Alert, Button, Dropdown, Form, Input, InputNumber, Space, Spin, Tag, Typography,
+} from 'antd';
+import { BulbOutlined, ThunderboltOutlined } from '@ant-design/icons';
+import { useTranslation } from 'react-i18next';
+
+import type { PromQLValidationResult } from '../services/alerts';
+import { validatePromQL } from '../services/alerts';
+
+const { Paragraph, Text } = Typography;
+
+export interface PromQLRuleEditorProps {
+  /** 当前 query_expr 值；undefined / null 表示未设置 */
+  queryExpr?: string | null;
+  /** for_duration_seconds */
+  forDuration?: number | null;
+  /** 值变更回调；编辑器自己不 useState，完全受控 */
+  onChange: (patch: { query_expr?: string | null; for_duration_seconds?: number | null }) => void;
+  /** 只读模式 —— 内置规则或 sync_at 展示场景 */
+  readonly?: boolean;
+}
+
+const EXAMPLES: { label: string; expr: string; hint: string }[] = [
+  {
+    label: '5xx 错误率 > 10%',
+    expr: 'rate(http_requests_total{status=~"5.."}[5m]) / rate(http_requests_total[5m]) > 0.1',
+    hint: '5 分钟窗口内 5xx 占比超过 10%',
+  },
+  {
+    label: 'CPU 均值 > 80%',
+    expr: 'avg by(instance) (100 - (avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) by (instance) * 100)) > 80',
+    hint: '按 instance 聚合 CPU 使用率',
+  },
+  {
+    label: '内存使用率 > 90%',
+    expr: '(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100 > 90',
+    hint: '可用内存 < 10%',
+  },
+  {
+    label: '磁盘 24h 内将填满',
+    expr: 'predict_linear(node_filesystem_avail_bytes{mountpoint="/"}[6h], 24 * 3600) < 0',
+    hint: 'predict_linear 按近 6h 趋势外推',
+  },
+  {
+    label: 'target 掉线',
+    expr: 'up == 0',
+    hint: 'Prometheus 最常见的 target down 告警',
+  },
+];
+
+export function PromQLRuleEditor({ queryExpr, forDuration, onChange, readonly }: PromQLRuleEditorProps) {
+  const { t } = useTranslation();
+  const [validating, setValidating] = useState(false);
+  const [validation, setValidation] = useState<PromQLValidationResult | null>(null);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const runValidation = useCallback(async (expr: string) => {
+    if (!expr.trim()) {
+      setValidation(null);
+      return;
+    }
+    setValidating(true);
+    try {
+      const result = await validatePromQL(expr);
+      setValidation(result);
+    } finally {
+      setValidating(false);
+    }
+  }, []);
+
+  // 表达式变更 → 600ms debounce 后自动校验
+  useEffect(() => {
+    if (!queryExpr || readonly) {
+      setValidation(null);
+      return;
+    }
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    debounceTimerRef.current = setTimeout(() => {
+      runValidation(queryExpr);
+    }, 600);
+    return () => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    };
+  }, [queryExpr, readonly, runValidation]);
+
+  const applyExample = (expr: string) => {
+    if (readonly) return;
+    onChange({ query_expr: expr });
+  };
+
+  const handleExprChange = (value: string) => {
+    if (readonly) return;
+    onChange({ query_expr: value.trim() || null });
+  };
+
+  const handleForChange = (value: number | null) => {
+    if (readonly) return;
+    onChange({ for_duration_seconds: value ?? null });
+  };
+
+  return (
+    <div data-testid="promql-rule-editor">
+      <Paragraph type="secondary" style={{ fontSize: 12, marginBottom: 8 }}>
+        {t('alerts.promqlEditorHint', '填写 PromQL 表达式后，规则会自动同步到 Prometheus 规则引擎。原有 metric+threshold 字段将被忽略。')}
+      </Paragraph>
+
+      <Form.Item
+        label={(
+          <Space>
+            <ThunderboltOutlined />
+            <span>PromQL Expression</span>
+            {validating && <Spin size="small" />}
+            {validation?.valid && <Tag color="success">valid</Tag>}
+            {validation && !validation.valid && <Tag color="error">invalid</Tag>}
+          </Space>
+        )}
+        required
+      >
+        <Input.TextArea
+          value={queryExpr ?? ''}
+          disabled={readonly}
+          onChange={(e) => handleExprChange(e.target.value)}
+          placeholder='rate(http_requests_total{status=~"5.."}[5m]) > 0.1'
+          autoSize={{ minRows: 3, maxRows: 8 }}
+          spellCheck={false}
+          style={{ fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace', fontSize: 13 }}
+        />
+      </Form.Item>
+
+      <Space style={{ marginBottom: 12 }} wrap>
+        <Dropdown
+          disabled={readonly}
+          menu={{
+            items: EXAMPLES.map((ex, i) => ({
+              key: String(i),
+              label: (
+                <Space direction="vertical" size={0} style={{ maxWidth: 360 }}>
+                  <Text strong>{ex.label}</Text>
+                  <Text code style={{ fontSize: 11 }}>{ex.expr}</Text>
+                  <Text type="secondary" style={{ fontSize: 11 }}>{ex.hint}</Text>
+                </Space>
+              ),
+              onClick: () => applyExample(ex.expr),
+            })),
+          }}
+          trigger={['click']}
+        >
+          <Button size="small" icon={<BulbOutlined />}>
+            {t('alerts.promqlExamples', '示例')}
+          </Button>
+        </Dropdown>
+        <Button
+          size="small"
+          loading={validating}
+          onClick={() => queryExpr && runValidation(queryExpr)}
+          disabled={readonly || !queryExpr}
+        >
+          {t('alerts.promqlValidateNow', '立即校验')}
+        </Button>
+      </Space>
+
+      {validation && !validation.valid && (
+        <Alert
+          type="error"
+          showIcon
+          style={{ marginBottom: 12 }}
+          message={validation.message ?? 'Invalid expression'}
+        />
+      )}
+      {validation?.valid && (
+        <Alert
+          type="success"
+          showIcon
+          style={{ marginBottom: 12 }}
+          message={renderValidationPreview(validation.data)}
+        />
+      )}
+
+      <Form.Item
+        label={t('alerts.promqlFor', '持续时长 for (秒)')}
+        tooltip={t('alerts.promqlForTip', '表达式持续满足这么久才触发告警，对应 Prometheus rule.for')}
+      >
+        <InputNumber
+          min={0}
+          step={30}
+          value={forDuration ?? undefined}
+          disabled={readonly}
+          onChange={handleForChange}
+          placeholder="默认取 duration_seconds，至少 60"
+          style={{ width: 240 }}
+          addonAfter="s"
+        />
+      </Form.Item>
+    </div>
+  );
+}
+
+/** 根据 PromQL 返回值渲染简短 preview */
+function renderValidationPreview(data: unknown): string {
+  if (!data || typeof data !== 'object') return '表达式合法';
+  const d = data as { resultType?: string; result?: unknown[] };
+  const resultType = d.resultType ?? 'unknown';
+  const count = Array.isArray(d.result) ? d.result.length : 0;
+  return `合法 · resultType=${resultType}, series=${count}`;
+}
+
+export default PromQLRuleEditor;

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -306,6 +306,7 @@ const en = {
       metric: 'Metric Alert',
       logKeyword: 'Log Keyword Alert',
       database: 'Database Alert',
+      promql: 'PromQL (Prometheus)',
       condition: 'Condition',
       threshold: 'Threshold',
       enabled: 'Enabled',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -306,6 +306,7 @@ const zh = {
       metric: '指标告警',
       logKeyword: '日志关键字',
       database: '数据库告警',
+      promql: 'PromQL (Prometheus)',
       condition: '条件',
       threshold: '阈值',
       enabled: '启用',

--- a/frontend/src/pages/AlertList.tsx
+++ b/frontend/src/pages/AlertList.tsx
@@ -16,6 +16,7 @@ import 'dayjs/locale/zh-cn';
 dayjs.extend(relativeTime);
 import api from '../services/api';
 import { alertService, notificationService, type NotificationChannel } from '../services/alerts';
+import { PromQLRuleEditor } from '../components/PromQLRuleEditor';
 import { databaseService } from '../services/databases';
 import type { DatabaseItem } from '../services/databases';
 import type { Alert, AlertRule } from '../services/alerts';
@@ -46,6 +47,9 @@ export default function AlertList() {
   const [ruleModalOpen, setRuleModalOpen] = useState(false);
   const [editingRule, setEditingRule] = useState<AlertRule | null>(null);
   const [ruleType, setRuleType] = useState<string>('metric');
+  // PromQL 模式的受控字段（Form 里用受控组件，避免跟 react-hook-form 冲突）
+  const [promqlExpr, setPromqlExpr] = useState<string | null>(null);
+  const [promqlFor, setPromqlFor] = useState<number | null>(null);
   const [dbList, setDbList] = useState<DatabaseItem[]>([]);
   const [notificationChannels, setNotificationChannels] = useState<NotificationChannel[]>([]);
   const [channelsLoading, setChannelsLoading] = useState(false);
@@ -313,6 +317,24 @@ export default function AlertList() {
     const payload = { ...values } as Record<string, unknown>;
     payload.silence_start = values.silence_start ? (values.silence_start as dayjs.Dayjs).format('HH:mm:ss') : null;
     payload.silence_end = values.silence_end ? (values.silence_end as dayjs.Dayjs).format('HH:mm:ss') : null;
+    // PromQL 模式：把受控字段补进 payload；后端要求 metric/threshold/operator 非空，
+    // 给合法默认值避开校验，实际触发走 query_expr。
+    if (ruleType === 'promql') {
+      if (!promqlExpr || !promqlExpr.trim()) {
+        messageApi.error('PromQL 表达式不能为空');
+        return;
+      }
+      payload.query_expr = promqlExpr;
+      payload.for_duration_seconds = promqlFor;
+      payload.rule_type = 'promql';
+      payload.metric = payload.metric || 'promql_expr';
+      payload.operator = payload.operator || '>';
+      payload.threshold = payload.threshold ?? 0;
+    } else {
+      // 非 PromQL 模式显式置空，避免从 PromQL 切回来留脏字段
+      payload.query_expr = null;
+      payload.for_duration_seconds = null;
+    }
     try {
       if (editingRule) {
         await alertService.updateRule(editingRule.id, payload as Partial<AlertRule>);
@@ -467,10 +489,15 @@ export default function AlertList() {
         <Space>
           <Button type="link" size="small" onClick={() => {
             setEditingRule(r);
-            setRuleType(r.rule_type || 'metric');
+            // 有 query_expr 的规则一律视作 PromQL 模式，优先于 rule_type 字段
+            const isPromql = Boolean(r.query_expr);
+            setRuleType(isPromql ? 'promql' : (r.rule_type || 'metric'));
+            setPromqlExpr(r.query_expr ?? null);
+            setPromqlFor(r.for_duration_seconds ?? null);
             const vals = { ...r } as Record<string, unknown>;
             if (r.silence_start) vals.silence_start = dayjs(r.silence_start, 'HH:mm:ss');
             if (r.silence_end) vals.silence_end = dayjs(r.silence_end, 'HH:mm:ss');
+            if (isPromql) vals.rule_type = 'promql';
             form.setFieldsValue(vals);
             loadDbList();
             loadNotificationChannels();
@@ -564,7 +591,7 @@ export default function AlertList() {
           children: (
             <>
               <Row justify="end" style={{ marginBottom: 16 }}>
-                <Button type="primary" onClick={() => { setEditingRule(null); setRuleType('metric'); form.resetFields(); setRuleModalOpen(true); loadDbList(); loadNotificationChannels(); }}>{t('alerts.createRule')}</Button>
+                <Button type="primary" onClick={() => { setEditingRule(null); setRuleType('metric'); setPromqlExpr(null); setPromqlFor(null); form.resetFields(); setRuleModalOpen(true); loadDbList(); loadNotificationChannels(); }}>{t('alerts.createRule')}</Button>
               </Row>
               <Card>
                 <Table dataSource={rules} columns={ruleColumns} rowKey="id" loading={rulesLoading} pagination={false} />
@@ -657,6 +684,7 @@ export default function AlertList() {
               { label: t('alerts.rules.metric'), value: 'metric' },
               { label: t('alerts.rules.logKeyword'), value: 'log_keyword' },
               { label: t('alerts.rules.database'), value: 'db_metric' },
+              { label: t('alerts.rules.promql', 'PromQL (Prometheus)'), value: 'promql' },
             ]} />
           </Form.Item>
 
@@ -681,6 +709,18 @@ export default function AlertList() {
               </Form.Item>
               <Form.Item name="log_service" label={t('alerts.rules.logService')}><Input placeholder="e.g.: nginx, app" /></Form.Item>
             </>
+          )}
+
+          {ruleType === 'promql' && (
+            <PromQLRuleEditor
+              queryExpr={promqlExpr}
+              forDuration={promqlFor}
+              onChange={(patch) => {
+                if ('query_expr' in patch) setPromqlExpr(patch.query_expr ?? null);
+                if ('for_duration_seconds' in patch) setPromqlFor(patch.for_duration_seconds ?? null);
+              }}
+              readonly={Boolean(editingRule?.is_builtin)}
+            />
           )}
 
           {ruleType === 'db_metric' && (

--- a/frontend/src/services/alerts.ts
+++ b/frontend/src/services/alerts.ts
@@ -78,6 +78,12 @@ export interface AlertRule {
   silence_end?: string | null;
   /** 关联的通知渠道 ID 列表 */
   notification_channel_ids?: number[] | null;
+  /** PromQL 表达式；非空时走 Prometheus sidecar 触发路径，否则走内置 metric+threshold */
+  query_expr?: string | null;
+  /** PromQL 规则的 for 字段（秒），即表达式持续满足的时长 */
+  for_duration_seconds?: number | null;
+  /** 上次同步到 Prometheus rules.yml 的 ISO 时间戳（只读）*/
+  prom_rule_synced_at?: string | null;
 }
 
 /** 通知渠道 */
@@ -139,7 +145,46 @@ export const alertService = {
   updateRule: (id: string, data: Partial<AlertRule>) => api.put(`/alert-rules/${id}`, data),
   /** 删除告警规则 */
   deleteRule: (id: string) => api.delete(`/alert-rules/${id}`),
+  /** 手动触发 AlertRule → Prometheus rules.yml 全量同步 */
+  syncPromRules: () => api.post('/alert-rules/prometheus/sync'),
+  /** 手动触发 Host/Service → Prometheus file_sd 导出 */
+  syncPromFileSd: () => api.post('/alert-rules/prometheus/file-sd-sync'),
 };
+
+/** PromQL 表达式即时校验响应（走 /promql/query?query=...&time=now）*/
+export interface PromQLValidationResult {
+  valid: boolean;
+  message?: string;
+  /** 原始 Prom 数据对象，便于展示 result preview */
+  data?: unknown;
+}
+
+/**
+ * 校验 PromQL 表达式：用 /api/v1/promql/query 跑一次 instant query，
+ * HTTP 200 → valid；4xx → 不合法（解析/执行失败）；5xx → 暂不可达。
+ * 用 __noToast 关闭全局错误 toast，让编辑器自己展示内联错误。
+ */
+export async function validatePromQL(expr: string): Promise<PromQLValidationResult> {
+  if (!expr || !expr.trim()) {
+    return { valid: false, message: '表达式不能为空' };
+  }
+  try {
+    const { data } = await api.get('/promql/query', {
+      params: { query: expr },
+      // @ts-expect-error 自定义 flag 用于关闭全局错误 toast
+      __noToast: true,
+    });
+    return { valid: true, data };
+  } catch (err: unknown) {
+    const e = err as { response?: { status?: number; data?: { detail?: string } } };
+    const status = e.response?.status;
+    const detail = e.response?.data?.detail ?? '未知错误';
+    if (status && status >= 400 && status < 500) {
+      return { valid: false, message: `解析错误：${detail}` };
+    }
+    return { valid: false, message: `Prometheus 服务暂不可达（${status ?? 'network'}）` };
+  }
+}
 
 /** 通知渠道服务 */
 export const notificationService = {

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,51 @@
+# Prometheus sidecar config for NightMend
+#
+# 顶层设计：
+#   Prometheus 作为 NightMend 的 TSDB 后端与 PromQL 执行引擎。
+#   - scrape NightMend backend 自己暴露的业务指标（/metrics）
+#   - 预留 scrape 第三方 exporter（node_exporter / mysqld_exporter 等）的位置
+#   - 预留 Alertmanager 对接位（出站方向，让 Prom 触发的告警回流 NightMend 的 webhook）
+#
+# 热加载：docker compose exec prometheus kill -HUP 1  或 curl -X POST :9090/-/reload
+# 详见 feat/prometheus-sidecar PR。
+
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+  external_labels:
+    cluster: nightmend
+    origin: sidecar
+
+# 规则文件目录（recording + alerting rules）。
+# Milestone 2 会把 NightMend AlertRule 同步到这里。
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+scrape_configs:
+  # Prometheus 自监控
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  # NightMend backend 的业务指标（告警数、remediation 执行数、AI token 用量等）。
+  # backend 容器在同一 compose network，service name = backend，内部端口 8000。
+  - job_name: nightmend_backend
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["backend:8000"]
+        labels:
+          component: backend
+
+  # file_sd 占位：Milestone 3 让 NightMend 输出 targets.json 描述被监控主机。
+  # - job_name: nightmend_hosts
+  #   file_sd_configs:
+  #     - files:
+  #         - /etc/prometheus/targets/hosts.json
+  #       refresh_interval: 30s
+
+# Alertmanager 对接占位：Milestone 2 启用。
+# alerting:
+#   alertmanagers:
+#     - static_configs:
+#         - targets: ["alertmanager:9093"]

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -37,12 +37,36 @@ scrape_configs:
         labels:
           component: backend
 
-  # file_sd 占位：Milestone 3 让 NightMend 输出 targets.json 描述被监控主机。
-  # - job_name: nightmend_hosts
-  #   file_sd_configs:
-  #     - files:
-  #         - /etc/prometheus/targets/hosts.json
-  #       refresh_interval: 30s
+  # NightMend 动态服务发现 — 主机级 node_exporter 抓取
+  # NightMend 后端定期把 Host 表导出到 hosts.json，Prom 每 30s 重读。
+  - job_name: nightmend_hosts
+    file_sd_configs:
+      - files:
+          - /etc/prometheus/targets/hosts.json
+        refresh_interval: 30s
+    relabel_configs:
+      # 把 hostname 提成 instance 标签，和既有 __name__ 体系对齐
+      - source_labels: [hostname]
+        target_label: instance
+
+  # NightMend 动态服务发现 — 服务级 blackbox probe
+  # 需要 blackbox_exporter 配合；默认 probe_module 已由 NightMend 打入 label。
+  - job_name: nightmend_services
+    file_sd_configs:
+      - files:
+          - /etc/prometheus/targets/services.json
+        refresh_interval: 30s
+    metrics_path: /probe
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [probe_module]
+        target_label: __param_module
+      - source_labels: [service_name]
+        target_label: instance
+      # 需要有 blackbox_exporter service 时才启用；profile 关闭即 scrape 失败被忽略
+      - target_label: __address__
+        replacement: blackbox:9115
 
 # Alertmanager 对接占位：Milestone 2 启用。
 # alerting:

--- a/prometheus/rules/.gitkeep
+++ b/prometheus/rules/.gitkeep
@@ -1,0 +1,3 @@
+# Recording + alerting rules 目录占位。
+# Milestone 2 会由 NightMend 后端自动同步规则文件到此目录，
+# 通过 POST http://prometheus:9090/-/reload 热加载。

--- a/prometheus/targets/.gitkeep
+++ b/prometheus/targets/.gitkeep
@@ -1,0 +1,2 @@
+# file_sd targets 目录占位。
+# Milestone 3 会由 NightMend 根据 hosts 表导出 targets.json 供 Prometheus 发现。


### PR DESCRIPTION
## Summary

Prometheus 集成完整 Milestone 1-5，把 NightMend 从"自研 mini 监控栈"升级为"Prometheus 生态 AI 增强层"。零新增 pip 依赖，全部 feature flag 灰度。

**战略定位**：Prometheus 告诉你坏了，NightMend 自己修好。

## 交付全景（5 个 milestone，27 文件，+2000 insertions，42 条后端测试）

### M1 — Sidecar 部署 + PromQL 查询转发
- docker-compose.yml 加 prometheus:v2.55.1 service（profile 守门）
- prometheus_remote.py 转发客户端（错误分层 Error vs Unavailable）
- promql_service.py 入口加 feature flag 分发 + sidecar 不可达自动 fallback 本地引擎
- 9 条测试

### M2 — AlertRule → rules.yml 同步 + Hot Reload
- alembic 033：AlertRule 新增 query_expr / for_duration_seconds / prom_rule_synced_at（全可空，向后兼容）
- prom_rules_sync.py 纯函数 build_rules_yaml + 原子写 + POST /-/reload
- CRUD 智能触发（只在 query_expr 相关字段动时同步）
- POST /alert-rules/prometheus/sync 手动端点
- 8 条测试

### M3 — Host/Service → file_sd 自动服务发现
- prom_file_sd.py 导出器（IP 优先级 private>ip_address>public，URL + host:port 双格式）
- prom_file_sd_task.py 每 60s 后台同步
- prometheus.yml 启用 nightmend_hosts + nightmend_services 两 job（relabel 对接 blackbox /probe）
- 15 条测试

### M4 — Remote Write 接收器（auth-proxy 模式）
- 关键决策：不自己解 snappy+protobuf，用 Prom v2.33+ 的 --web.enable-remote-write-receiver，NightMend 做鉴权透明代理
- Bearer token + hmac.compare_digest，10 MB body 上限，敏感头过滤
- 10 条测试

### M5 — 前端 PromQL 规则编辑器
- components/PromQLRuleEditor.tsx：600ms debounce 自动校验 / 5 条示例下拉 / 立即校验 / preview
- services/alerts.ts validatePromQL：走 /promql/query + __noToast，HTTP 状态分层
- pages/AlertList.tsx：rule_type 新增 promql 选项；编辑时优先识别 query_expr 自动切换；保存时智能字段注入/清理
- i18n zh/en 双语标签
- 完整对接 M2 后端链路：保存 → _best_effort_sync → rules.yml → /-/reload → Prom 生效

## 架构闭环

| 方向 | 抓手 | 对接点 |
|---|---|---|
| NightMend → Prom | M2 rules.yml + M3 file_sd targets | 让 Prom 读 NightMend 的 AlertRule / Host / Service 表 |
| Prom → NightMend | M1 promql 转发（读）+ M4 remote_write（写） | 让 NightMend 复用 Prom 的 TSDB + PromQL + 生态 |
| 用户 → 规则 | M5 PromQL 编辑器 | 非运维也能写 PromQL 表达式并实时验证 |

## 启用契约

```bash
# 1. 启动 sidecar
docker compose --profile prometheus up -d prometheus

# 2. .env 开关
PROMETHEUS_REMOTE_ENABLED=true
PROM_REMOTE_WRITE_TOKEN=$(openssl rand -hex 32)

# 3. 重启 backend
docker compose restart backend
```

## 验收证据

- 全部 prom 相关后端测试 42/42 passed
- 回归（alerts/hosts etc）21/21 passed
- ruff 新文件 All checks passed
- ruff main.py baseline 54（noqa 规避，零新增）
- frontend tsc clean
- frontend eslint 新文件 All checks passed

## Commits

1. step 1 — compose + promql forwarding w/ fallback (93f397b)
2. step 2 — AlertRule.query_expr + rules.yml sync (09767aa)
3. step 3 — file_sd auto service discovery (a2a8991)
4. step 4 — remote_write receiver as auth-proxy (c8eefb1)
5. step 5 — frontend PromQL rule editor (2597b79)

🤖 Generated with Claude Code