### PR TITLE
feat(prometheus-m7): Alertmanager bi-directional routing

### DIFF
--- a/alertmanager/Dockerfile
+++ b/alertmanager/Dockerfile
@@ -1,0 +1,15 @@
+# NightMend-flavored Alertmanager：官方镜像 + envsubst + 启动脚本
+# 只改 entrypoint，Alertmanager 本身版本由 FROM 锁定。
+FROM prom/alertmanager:v0.27.0
+
+USER root
+# busybox 自带 sh，但无 envsubst；装 gettext 提供 envsubst
+RUN apk add --no-cache gettext
+
+COPY alertmanager.yml.template /etc/alertmanager/alertmanager.yml.template
+COPY entrypoint.sh /usr/local/bin/nightmend-entrypoint.sh
+RUN chmod +x /usr/local/bin/nightmend-entrypoint.sh
+
+USER nobody
+EXPOSE 9093
+ENTRYPOINT ["/usr/local/bin/nightmend-entrypoint.sh"]

--- a/alertmanager/alertmanager.yml.template
+++ b/alertmanager/alertmanager.yml.template
@@ -1,0 +1,40 @@
+# Alertmanager 配置模板 (template) — NightMend 集成
+#
+# 顶层设计：
+#   Prom sidecar 的 rules（M2 同步）触发 → Alertmanager（分组/去重/抑制）→
+#   webhook 投递到 NightMend backend → AI 诊断 + runbook。
+#
+# 本文件是 template，容器启动时 entrypoint 脚本用 envsubst 把 $ALERTMANAGER_WEBHOOK_TOKEN
+# 等占位符替换成 .env 的实际值，生成 /etc/alertmanager/alertmanager.yml 再启动。
+
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: nightmend-webhook
+  group_by: [alertname, instance, nightmend_rule_id]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    - matchers:
+        - severity = "critical"
+      group_wait: 10s
+      group_interval: 1m
+      repeat_interval: 30m
+      receiver: nightmend-webhook
+
+inhibit_rules:
+  - source_matchers: [severity = "critical"]
+    target_matchers: [severity = "warning"]
+    equal: [alertname, instance]
+
+receivers:
+  - name: nightmend-webhook
+    webhook_configs:
+      - url: ${NIGHTMEND_WEBHOOK_URL}
+        send_resolved: true
+        http_config:
+          authorization:
+            type: Bearer
+            credentials: ${ALERTMANAGER_WEBHOOK_TOKEN}

--- a/alertmanager/entrypoint.sh
+++ b/alertmanager/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Alertmanager entrypoint：用 envsubst 渲染 template → 真实配置，再 exec 官方 binary。
+#
+# 环境变量：
+#   NIGHTMEND_WEBHOOK_URL         例如 http://backend:8000/api/v1/webhooks/alertmanager
+#   ALERTMANAGER_WEBHOOK_TOKEN    与 NightMend settings.alertmanager_webhook_token 一致
+set -eu
+
+TEMPLATE_PATH="${ALERTMANAGER_TEMPLATE:-/etc/alertmanager/alertmanager.yml.template}"
+OUTPUT_PATH="${ALERTMANAGER_CONFIG:-/etc/alertmanager/alertmanager.yml}"
+
+: "${NIGHTMEND_WEBHOOK_URL:?NIGHTMEND_WEBHOOK_URL is required}"
+: "${ALERTMANAGER_WEBHOOK_TOKEN:?ALERTMANAGER_WEBHOOK_TOKEN is required (must match NightMend settings)}"
+
+# 只渲染已知变量，防止意外展开 $foo
+export NIGHTMEND_WEBHOOK_URL ALERTMANAGER_WEBHOOK_TOKEN
+envsubst '${NIGHTMEND_WEBHOOK_URL} ${ALERTMANAGER_WEBHOOK_TOKEN}' \
+    < "$TEMPLATE_PATH" > "$OUTPUT_PATH"
+
+# 启动 Alertmanager，其他参数透传
+exec /bin/alertmanager \
+    --config.file="$OUTPUT_PATH" \
+    --storage.path=/alertmanager \
+    --web.listen-address=:9093 \
+    "$@"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -145,6 +145,8 @@ class Settings(BaseSettings):
     prometheus_remote_timeout_seconds: float = 15.0
     # Remote Write 接收端点 Bearer token；空 = 拒绝所有 Bearer 调用（仅允许 User JWT）
     prom_remote_write_token: str = ""
+    # Alertmanager sidecar 反向路由地址；空 = 反向 silence API 禁用
+    alertmanager_url: str = "http://alertmanager:9093"
 
     # AlertManager Bridge 配置 (AlertManager Bridge Configuration)
     alertmanager_webhook_token: str = ""  # Bearer token for webhook auth, generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -77,6 +77,7 @@ from app.routers import custom_runbooks
 from app.routers import promql
 from app.routers import webhooks
 from app.routers import prom_remote_write  # noqa: E402  (main.py 存量 E402 debt 规避)
+from app.routers import alertmanager_silences  # noqa: E402
 from app.routers import alert_stream
 from app.api.v1 import data_retention
 from app.api.v1 import alert_deduplication
@@ -316,6 +317,7 @@ app.include_router(custom_runbooks.router)  # 自定义 Runbook 管理 (Custom R
 app.include_router(promql.router)  # PromQL 查询 (PromQL Query Engine)
 app.include_router(webhooks.router)  # 外部告警源 Webhook (External Alert Source Webhooks)
 app.include_router(prom_remote_write.router)  # Prometheus Remote Write 接收器 (Prometheus Remote Write Receiver)
+app.include_router(alertmanager_silences.router)  # Alertmanager Silence 反向路由 (Alertmanager Silence Reverse Routing)
 app.include_router(alert_stream.router)  # 告警诊断 SSE 流 (Alert Diagnosis SSE Stream)
 
 

--- a/backend/app/routers/alertmanager_silences.py
+++ b/backend/app/routers/alertmanager_silences.py
@@ -1,0 +1,102 @@
+"""Alertmanager Silence 管理端点。
+
+反向路由（M7）：NightMend → Alertmanager /api/v2/silences
+让用户/Runbook 直接在 NightMend UI 上管理 Alertmanager silences，
+不需要切到 AM Web UI 也不会丢失审计链路。
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import timedelta
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.deps import get_current_user, get_operator_user
+from app.models.user import User
+from app.services import alertmanager_client as am
+from app.services.audit import log_audit
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/alertmanager", tags=["alertmanager"])
+
+
+class Matcher(BaseModel):
+    name: str
+    value: str
+    isRegex: bool = False
+    isEqual: bool = True
+
+
+class CreateSilenceRequest(BaseModel):
+    matchers: list[Matcher] = Field(..., min_length=1, max_length=20)
+    duration_seconds: int = Field(..., ge=60, le=7 * 24 * 3600, description="60s ~ 7d")
+    comment: str = Field(..., min_length=1, max_length=500)
+
+
+@router.post("/silences")
+async def create_silence(
+    payload: CreateSilenceRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_operator_user),
+):
+    try:
+        silence_id = await am.create_silence(
+            matchers=[m.model_dump() for m in payload.matchers],
+            duration=timedelta(seconds=payload.duration_seconds),
+            created_by=f"nightmend-user:{user.id}",
+            comment=payload.comment,
+        )
+    except am.AlertmanagerUnavailable as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+
+    await log_audit(
+        db, user.id, "create_silence", "alertmanager", 0,
+        json.dumps({"silence_id": silence_id, **payload.model_dump()}),
+        request.client.host if request.client else None,
+    )
+    await db.commit()
+    return {"silence_id": silence_id}
+
+
+@router.delete("/silences/{silence_id}", status_code=204)
+async def delete_silence(
+    silence_id: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_operator_user),
+):
+    try:
+        await am.delete_silence(silence_id)
+    except am.AlertmanagerUnavailable as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+
+    await log_audit(
+        db, user.id, "delete_silence", "alertmanager", 0,
+        json.dumps({"silence_id": silence_id}),
+        request.client.host if request.client else None,
+    )
+    await db.commit()
+
+
+@router.get("/silences")
+async def list_silences(
+    active_only: bool = True,
+    _user: User = Depends(get_current_user),
+) -> list[dict[str, Any]]:
+    try:
+        return await am.list_silences(active_only=active_only)
+    except am.AlertmanagerUnavailable as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+
+
+@router.get("/health")
+async def alertmanager_health(_user: User = Depends(get_current_user)):
+    """UI 展示 Alertmanager 可达性。"""
+    return {"healthy": await am.is_healthy()}

--- a/backend/app/services/alertmanager_client.py
+++ b/backend/app/services/alertmanager_client.py
@@ -1,0 +1,134 @@
+"""Alertmanager 反向路由客户端 (Alertmanager Reverse Route Client)
+
+正向：Prom → AM → NightMend webhook（由 alertmanager/alertmanager.yml 配置完成）
+反向：NightMend → AM silence API
+
+反向用途：
+    - Runbook 执行期间，主动把目标告警设成 silence，防止 flap / 重复告警噪音
+    - 用户在 UI 点"静默 1h"按钮直接投递到 AM（而不是只在 NightMend 自己记忆）
+    - 维护窗口：批量 silence 某一批主机
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+import httpx
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class AlertmanagerUnavailable(RuntimeError):
+    pass
+
+
+def _iso(dt: datetime) -> str:
+    """Alertmanager 期望 RFC3339 (UTC, 带 Z 或 +00:00)。"""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+async def create_silence(
+    matchers: list[dict],
+    *,
+    duration: timedelta,
+    created_by: str,
+    comment: str,
+    starts_at: datetime | None = None,
+) -> str:
+    """
+    创建一条 silence，返回 silence ID。
+
+    matchers 示例：
+        [{"name": "alertname", "value": "HighCPU", "isRegex": False, "isEqual": True},
+         {"name": "instance", "value": "web-0[12]", "isRegex": True, "isEqual": True}]
+
+    生产调用示例（runbook 执行前）：
+        await create_silence(
+            [{"name": "alertname", "value": rule.name, "isRegex": False, "isEqual": True}],
+            duration=timedelta(minutes=10),
+            created_by="nightmend-runbook",
+            comment=f"auto-silence during remediation run {log_id}",
+        )
+    """
+    if not settings.alertmanager_url:
+        raise AlertmanagerUnavailable("alertmanager_url not configured")
+
+    start = starts_at or datetime.now(timezone.utc)
+    end = start + duration
+    payload = {
+        "matchers": matchers,
+        "startsAt": _iso(start),
+        "endsAt": _iso(end),
+        "createdBy": created_by,
+        "comment": comment,
+    }
+
+    url = f"{settings.alertmanager_url.rstrip('/')}/api/v2/silences"
+    try:
+        async with httpx.AsyncClient(timeout=settings.prometheus_remote_timeout_seconds) as client:
+            response = await client.post(url, json=payload)
+    except httpx.RequestError as exc:
+        logger.warning("Alertmanager silence POST failed: %s", exc)
+        raise AlertmanagerUnavailable(f"Alertmanager unreachable: {exc}") from exc
+
+    if response.status_code >= 400:
+        raise AlertmanagerUnavailable(
+            f"Alertmanager rejected silence: status={response.status_code} body={response.text[:200]}"
+        )
+
+    data = response.json()
+    silence_id = data.get("silenceID") or data.get("silenceId") or data.get("id")
+    if not silence_id:
+        raise AlertmanagerUnavailable(f"Alertmanager response missing silenceID: {data}")
+    logger.info("silence created: id=%s by=%s duration=%s", silence_id, created_by, duration)
+    return silence_id
+
+
+async def delete_silence(silence_id: str) -> None:
+    """提前解除 silence。"""
+    if not settings.alertmanager_url:
+        raise AlertmanagerUnavailable("alertmanager_url not configured")
+    url = f"{settings.alertmanager_url.rstrip('/')}/api/v2/silence/{silence_id}"
+    try:
+        async with httpx.AsyncClient(timeout=settings.prometheus_remote_timeout_seconds) as client:
+            response = await client.delete(url)
+    except httpx.RequestError as exc:
+        raise AlertmanagerUnavailable(f"Alertmanager unreachable: {exc}") from exc
+    if response.status_code >= 400 and response.status_code != 404:
+        raise AlertmanagerUnavailable(
+            f"delete silence failed: status={response.status_code} body={response.text[:200]}"
+        )
+
+
+async def list_silences(active_only: bool = True) -> list[dict]:
+    """列出当前 silences，用于 UI 展示。"""
+    if not settings.alertmanager_url:
+        raise AlertmanagerUnavailable("alertmanager_url not configured")
+    url = f"{settings.alertmanager_url.rstrip('/')}/api/v2/silences"
+    try:
+        async with httpx.AsyncClient(timeout=settings.prometheus_remote_timeout_seconds) as client:
+            response = await client.get(url)
+    except httpx.RequestError as exc:
+        raise AlertmanagerUnavailable(f"Alertmanager unreachable: {exc}") from exc
+    if response.status_code >= 400:
+        raise AlertmanagerUnavailable(f"list silences failed: {response.status_code}")
+    silences = response.json() or []
+    if active_only:
+        silences = [s for s in silences if (s.get("status") or {}).get("state") == "active"]
+    return silences
+
+
+async def is_healthy() -> bool:
+    if not settings.alertmanager_url:
+        return False
+    url = f"{settings.alertmanager_url.rstrip('/')}/-/healthy"
+    try:
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            response = await client.get(url)
+        return response.status_code == 200
+    except httpx.RequestError:
+        return False

--- a/backend/tests/test_alertmanager_silences.py
+++ b/backend/tests/test_alertmanager_silences.py
@@ -1,0 +1,293 @@
+"""Alertmanager 反向路由（silence）客户端 + 端点测试。
+
+覆盖：
+  client 单元:
+    - _iso 把 naive / aware datetime 转成 UTC RFC3339
+    - create_silence 成功 / 4xx / 连接失败
+    - delete_silence 404 视为成功；5xx 抛
+    - list_silences active_only 过滤
+  路由集成（带 client fixture）：
+    - POST /silences 透传参数 + 返回 silence_id
+    - DELETE /silences/{id} 204
+    - viewer 调 POST/DELETE → 403
+    - alertmanager 不可达 → 502
+    - list 活跃过滤
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import httpx
+import pytest
+from httpx import AsyncClient
+
+from app.core.config import settings
+from app.services import alertmanager_client as am
+
+
+# ─── pure function tests ────────────────────────────────────────────
+
+
+def test_iso_naive_datetime_converts_to_utc():
+    dt = datetime(2026, 4, 21, 12, 0, 0)  # naive
+    result = am._iso(dt)
+    assert result.endswith("Z")
+    assert "2026-04-21T12:00:00" in result
+
+
+def test_iso_aware_datetime_preserves_utc():
+    dt = datetime(2026, 4, 21, 4, 0, 0, tzinfo=timezone(timedelta(hours=8)))
+    result = am._iso(dt)
+    # 8 点 UTC+8 → 00 点 UTC
+    assert "2026-04-20T20:00:00" in result
+    assert result.endswith("Z")
+
+
+# ─── client httpx-mocked ───────────────────────────────────────────
+
+
+class _Resp:
+    def __init__(self, status_code: int, body: dict | str):
+        self.status_code = status_code
+        self._body = body
+        self.text = body if isinstance(body, str) else ""
+
+    def json(self):
+        if isinstance(self._body, str):
+            raise ValueError("not json")
+        return self._body
+
+
+class _Client:
+    def __init__(self, response=None, exc=None, captured=None):
+        self._response = response
+        self._exc = exc
+        self._captured = captured if captured is not None else {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def post(self, url, json=None):
+        self._captured["url"] = url
+        self._captured["json"] = json
+        if self._exc:
+            raise self._exc
+        return self._response
+
+    async def delete(self, url):
+        self._captured["url"] = url
+        if self._exc:
+            raise self._exc
+        return self._response
+
+    async def get(self, url):
+        self._captured["url"] = url
+        if self._exc:
+            raise self._exc
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_create_silence_success():
+    captured: dict = {}
+    resp = _Resp(200, {"silenceID": "ab-12"})
+    with patch.object(settings, "alertmanager_url", "http://alertmanager:9093"), \
+         patch("app.services.alertmanager_client.httpx.AsyncClient", return_value=_Client(response=resp, captured=captured)):
+        sid = await am.create_silence(
+            [{"name": "alertname", "value": "HighCPU", "isRegex": False, "isEqual": True}],
+            duration=timedelta(minutes=10),
+            created_by="test",
+            comment="unit test",
+        )
+    assert sid == "ab-12"
+    assert captured["url"].endswith("/api/v2/silences")
+    sent = captured["json"]
+    assert sent["createdBy"] == "test"
+    assert sent["comment"] == "unit test"
+    assert sent["matchers"][0]["name"] == "alertname"
+
+
+@pytest.mark.asyncio
+async def test_create_silence_returns_silenceid_alt_key():
+    """AM 不同版本键名可能是 silenceId / id，客户端要容错。"""
+    resp = _Resp(200, {"id": "xx-77"})
+    with patch.object(settings, "alertmanager_url", "http://alertmanager:9093"), \
+         patch("app.services.alertmanager_client.httpx.AsyncClient", return_value=_Client(response=resp)):
+        sid = await am.create_silence(
+            [{"name": "alertname", "value": "x", "isRegex": False, "isEqual": True}],
+            duration=timedelta(minutes=5), created_by="t", comment="c",
+        )
+    assert sid == "xx-77"
+
+
+@pytest.mark.asyncio
+async def test_create_silence_4xx_raises_unavailable():
+    resp = _Resp(400, "bad matchers")
+    with patch.object(settings, "alertmanager_url", "http://alertmanager:9093"), \
+         patch("app.services.alertmanager_client.httpx.AsyncClient", return_value=_Client(response=resp)):
+        with pytest.raises(am.AlertmanagerUnavailable):
+            await am.create_silence(
+                [{"name": "alertname", "value": "x", "isRegex": False, "isEqual": True}],
+                duration=timedelta(minutes=5), created_by="t", comment="c",
+            )
+
+
+@pytest.mark.asyncio
+async def test_create_silence_connection_error_raises_unavailable():
+    with patch.object(settings, "alertmanager_url", "http://alertmanager:9093"), \
+         patch("app.services.alertmanager_client.httpx.AsyncClient",
+               return_value=_Client(exc=httpx.ConnectError("dns fail"))):
+        with pytest.raises(am.AlertmanagerUnavailable):
+            await am.create_silence(
+                [{"name": "alertname", "value": "x", "isRegex": False, "isEqual": True}],
+                duration=timedelta(minutes=5), created_by="t", comment="c",
+            )
+
+
+@pytest.mark.asyncio
+async def test_delete_silence_404_is_success():
+    """已删除的 silence 再删应视为成功。"""
+    resp = _Resp(404, "not found")
+    with patch.object(settings, "alertmanager_url", "http://alertmanager:9093"), \
+         patch("app.services.alertmanager_client.httpx.AsyncClient", return_value=_Client(response=resp)):
+        # 不抛
+        await am.delete_silence("some-id")
+
+
+@pytest.mark.asyncio
+async def test_delete_silence_5xx_raises():
+    resp = _Resp(500, "boom")
+    with patch.object(settings, "alertmanager_url", "http://alertmanager:9093"), \
+         patch("app.services.alertmanager_client.httpx.AsyncClient", return_value=_Client(response=resp)):
+        with pytest.raises(am.AlertmanagerUnavailable):
+            await am.delete_silence("some-id")
+
+
+@pytest.mark.asyncio
+async def test_list_silences_active_only_filters():
+    resp = _Resp(200, [
+        {"id": "a1", "status": {"state": "active"}},
+        {"id": "a2", "status": {"state": "expired"}},
+        {"id": "a3", "status": {"state": "pending"}},
+    ])
+    with patch.object(settings, "alertmanager_url", "http://alertmanager:9093"), \
+         patch("app.services.alertmanager_client.httpx.AsyncClient", return_value=_Client(response=resp)):
+        active = await am.list_silences(active_only=True)
+    assert [s["id"] for s in active] == ["a1"]
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_url_raises_unavailable():
+    with patch.object(settings, "alertmanager_url", ""):
+        with pytest.raises(am.AlertmanagerUnavailable):
+            await am.create_silence(
+                [{"name": "alertname", "value": "x", "isRegex": False, "isEqual": True}],
+                duration=timedelta(minutes=5), created_by="t", comment="c",
+            )
+        assert await am.is_healthy() is False
+
+
+# ─── Router integration ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_post_silence_endpoint(client: AsyncClient, auth_headers):
+    resp = _Resp(200, {"silenceID": "id-1"})
+    with patch.object(settings, "alertmanager_url", "http://alertmanager:9093"), \
+         patch("app.services.alertmanager_client.httpx.AsyncClient", return_value=_Client(response=resp)):
+        response = await client.post(
+            "/api/v1/alertmanager/silences",
+            headers=auth_headers,
+            json={
+                "matchers": [{"name": "alertname", "value": "x", "isRegex": False, "isEqual": True}],
+                "duration_seconds": 600,
+                "comment": "maintenance",
+            },
+        )
+    assert response.status_code == 200
+    assert response.json()["silence_id"] == "id-1"
+
+
+@pytest.mark.asyncio
+async def test_post_silence_viewer_forbidden(client: AsyncClient, viewer_headers):
+    response = await client.post(
+        "/api/v1/alertmanager/silences",
+        headers=viewer_headers,
+        json={
+            "matchers": [{"name": "alertname", "value": "x", "isRegex": False, "isEqual": True}],
+            "duration_seconds": 600,
+            "comment": "maintenance",
+        },
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_post_silence_alertmanager_unavailable_returns_502(client: AsyncClient, auth_headers):
+    with patch.object(settings, "alertmanager_url", "http://alertmanager:9093"), \
+         patch("app.services.alertmanager_client.httpx.AsyncClient",
+               return_value=_Client(exc=httpx.ConnectError("dns fail"))):
+        response = await client.post(
+            "/api/v1/alertmanager/silences",
+            headers=auth_headers,
+            json={
+                "matchers": [{"name": "alertname", "value": "x", "isRegex": False, "isEqual": True}],
+                "duration_seconds": 600,
+                "comment": "maintenance",
+            },
+        )
+    assert response.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_delete_silence_endpoint(client: AsyncClient, auth_headers):
+    resp = _Resp(200, {})
+    with patch.object(settings, "alertmanager_url", "http://alertmanager:9093"), \
+         patch("app.services.alertmanager_client.httpx.AsyncClient", return_value=_Client(response=resp)):
+        response = await client.delete(
+            "/api/v1/alertmanager/silences/the-id",
+            headers=auth_headers,
+        )
+    assert response.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_list_silences_endpoint(client: AsyncClient, auth_headers):
+    resp = _Resp(200, [{"id": "a1", "status": {"state": "active"}}])
+    with patch.object(settings, "alertmanager_url", "http://alertmanager:9093"), \
+         patch("app.services.alertmanager_client.httpx.AsyncClient", return_value=_Client(response=resp)):
+        response = await client.get(
+            "/api/v1/alertmanager/silences",
+            headers=auth_headers,
+        )
+    assert response.status_code == 200
+    assert response.json()[0]["id"] == "a1"
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint(client: AsyncClient, auth_headers):
+    resp = _Resp(200, "")
+    with patch.object(settings, "alertmanager_url", "http://alertmanager:9093"), \
+         patch("app.services.alertmanager_client.httpx.AsyncClient", return_value=_Client(response=resp)):
+        response = await client.get("/api/v1/alertmanager/health", headers=auth_headers)
+    assert response.status_code == 200
+    assert response.json()["healthy"] is True
+
+
+@pytest.mark.asyncio
+async def test_silence_rejects_absurd_duration(client: AsyncClient, auth_headers):
+    # <60s 被 Pydantic 拒绝
+    response = await client.post(
+        "/api/v1/alertmanager/silences",
+        headers=auth_headers,
+        json={
+            "matchers": [{"name": "alertname", "value": "x", "isRegex": False, "isEqual": True}],
+            "duration_seconds": 5,
+            "comment": "too short",
+        },
+    )
+    assert response.status_code == 422

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,31 @@ services:
     profiles:
       - prometheus
 
+  # Alertmanager — Prometheus 告警分组/去重/抑制，回投 NightMend webhook (可选)
+  # 启用方式: docker compose --profile prometheus up -d alertmanager
+  # 闭环：Prom rule fire → AM → /api/v1/webhooks/alertmanager → AI 诊断 + runbook
+  alertmanager:
+    build: ./alertmanager
+    environment:
+      TZ: Asia/Shanghai
+      NIGHTMEND_WEBHOOK_URL: ${NIGHTMEND_WEBHOOK_URL:-http://backend:8000/api/v1/webhooks/alertmanager}
+      # 必须非空；由 alertmanager/entrypoint.sh 在容器启动时强制校验
+      ALERTMANAGER_WEBHOOK_TOKEN: ${ALERTMANAGER_WEBHOOK_TOKEN:-}
+    ports:
+      - "127.0.0.1:${ALERTMANAGER_PORT:-9093}:9093"
+    volumes:
+      - alertmanagerdata:/alertmanager
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9093/-/healthy"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+    depends_on:
+      - backend
+    restart: unless-stopped
+    profiles:
+      - prometheus
+
   # Grafana Loki 日志聚合 (Grafana Loki Log Aggregation) - 可选
   loki:
     image: grafana/loki:2.9.0
@@ -168,3 +193,4 @@ volumes:
   clickhousedata:
   lokidata:
   prometheusdata:
+  alertmanagerdata:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -68,8 +68,11 @@ scrape_configs:
       - target_label: __address__
         replacement: blackbox:9115
 
-# Alertmanager 对接占位：Milestone 2 启用。
-# alerting:
-#   alertmanagers:
-#     - static_configs:
-#         - targets: ["alertmanager:9093"]
+# Alertmanager 对接（M7 启用）
+# 规则触发后投递到 alertmanager:9093，由 AM 去重/分组/抑制后回投 NightMend webhook。
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+      timeout: 10s
+      api_version: v2


### PR DESCRIPTION
替代原 #46(其 base `feat/prometheus-sidecar` 随 #44 合并删除而被自动关闭)。内容不变,base 改为 main。

原 #46: https://github.com/LinChuang2008/nightmend/pull/46