### PR TITLE
fix: 日志脱敏覆盖惰性格式化写法,防止 logger.info(fmt, token) 泄漏明文

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # NightMend — Project Instructions
 
+## 项目级配置（架构师-工程师协作）
+- **Vault 根路径**: `/Users/wangchengbin/Documents/Obsidian/Knowledge/dev.nosync/NightMend-vault/`（sessions/ decisions/ knowledge/ board/，模板在 dev.nosync 根目录共用）
+- **Notion 项目映射**: 本目录 → Projects 库「NightMend」
+
 ## Design System
 Always read DESIGN.md before making any visual or UI decisions.
 All font choices, colors, spacing, and aesthetic direction are defined there.

--- a/backend/app/core/log_redaction.py
+++ b/backend/app/core/log_redaction.py
@@ -53,10 +53,21 @@ class RedactionFilter(logging.Filter):
     """对 record.msg 与 record.args 做脱敏；filter 必须返回 True 放行。"""
 
     def filter(self, record: logging.LogRecord) -> bool:
+        if record.args:
+            try:
+                message = record.getMessage()
+            except Exception:
+                # Bad lazy-format records must not break the logging path.
+                if isinstance(record.msg, str):
+                    record.msg = _scrub(record.msg)
+                record.args = _scrub_any(record.args)  # type: ignore[assignment]
+            else:
+                record.msg = _scrub(message)
+                record.args = ()
+            return True
+
         if isinstance(record.msg, str):
             record.msg = _scrub(record.msg)
-        if record.args:
-            record.args = _scrub_any(record.args)  # type: ignore[assignment]
         return True
 
 

--- a/backend/tests/test_log_redaction.py
+++ b/backend/tests/test_log_redaction.py
@@ -1,0 +1,122 @@
+import io
+import logging
+
+import pytest
+
+from app.core.log_redaction import RedactionFilter
+
+
+REDACTED = "***REDACTED***"
+
+
+@pytest.fixture
+def memory_logger(request):
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    handler.addFilter(RedactionFilter())
+
+    logger = logging.getLogger(f"{__name__}.{request.node.name}")
+    previous_level = logger.level
+    previous_propagate = logger.propagate
+    previous_handlers = list(logger.handlers)
+    previous_filters = list(logger.filters)
+
+    logger.handlers = [handler]
+    logger.filters = []
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+    try:
+        yield logger, stream
+    finally:
+        logger.handlers = previous_handlers
+        logger.filters = previous_filters
+        logger.setLevel(previous_level)
+        logger.propagate = previous_propagate
+        handler.close()
+
+
+class RecordingHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+def test_redacts_lazy_authorization_bearer(memory_logger):
+    logger, stream = memory_logger
+    token = "eyJhbGciOiJIUzI1NiJ9.secret-token"
+
+    logger.info("Authorization: Bearer %s", token)
+
+    output = stream.getvalue()
+    assert REDACTED in output
+    assert token not in output
+
+
+@pytest.mark.parametrize(
+    ("message", "secret"),
+    [
+        ("Authorization: Bearer auth-secret", "auth-secret"),
+        ("Bearer baretoken123", "baretoken123"),
+        ("api_key=query-secret", "query-secret"),
+        ('{"token": "json-secret"}', "json-secret"),
+    ],
+)
+def test_redacts_existing_preformatted_patterns(memory_logger, message, secret):
+    logger, stream = memory_logger
+
+    logger.info(message)
+
+    output = stream.getvalue()
+    assert REDACTED in output
+    assert secret not in output
+
+
+def test_redacts_token_after_multiple_lazy_args(memory_logger):
+    logger, stream = memory_logger
+    token = "abc12345"
+
+    logger.info("user=%s token=%s", "alice", token)
+
+    output = stream.getvalue()
+    assert "user=alice" in output
+    assert f"token={REDACTED}" in output
+    assert token not in output
+
+
+def test_mismatched_msg_args_do_not_raise_or_stop_record_flow():
+    handler = RecordingHandler()
+    handler.addFilter(RedactionFilter())
+    logger = logging.getLogger(f"{__name__}.mismatched")
+    previous_level = logger.level
+    previous_propagate = logger.propagate
+    previous_handlers = list(logger.handlers)
+    previous_filters = list(logger.filters)
+
+    logger.handlers = [handler]
+    logger.filters = []
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+    try:
+        logger.info("val %s %s", "only-one")
+    finally:
+        logger.handlers = previous_handlers
+        logger.filters = previous_filters
+        logger.setLevel(previous_level)
+        logger.propagate = previous_propagate
+        handler.close()
+
+    assert len(handler.records) == 1
+
+
+def test_non_string_message_does_not_raise(memory_logger):
+    logger, stream = memory_logger
+
+    logger.info(ValueError("boom"))
+
+    assert "boom" in stream.getvalue()


### PR DESCRIPTION
## 背景
#43 安全补评审 Major 1:RedactionFilter 对 msg 与 args 分别在格式化之前脱敏,惰性写法 `logger.info("Authorization: Bearer %s", token)` 两边正则都不匹配,`getMessage()` 拼出明文 token。

## 修复
- `record.args` 非空时先 `getMessage()` 完成 % 格式化,对完整串 `_scrub` 后回写 `record.msg`、清空 `record.args`;
- 格式化失败(msg/args 错配等)退回原逐项脱敏兜底,不阻断日志链路;
- 4 个既有脱敏正则未动;另含 CLAUDE.md 项目级配置补充(独立 chore 提交)。

## 测试
- 新增 `tests/test_log_redaction.py` 8 例:惰性写法、多参数、args 错配不抛错、非字符串 msg、4 个既有正则回归——全过。
- 全量 pytest:614 passed(当时基线),无回归。

Authored-by: codex, Reviewed-by: claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)