### PR TITLE
fix: Webhook XFF 取值防伪造(按可信代理跳数右取)+ 恢复 docstring

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -154,6 +154,7 @@ class Settings(BaseSettings):
     # 若请求经过反向代理，需设置 webhook_trust_forwarded=True 并确保 proxy 可信。
     alertmanager_webhook_allowed_ips: str = ""
     webhook_trust_forwarded: bool = False  # 是否信任 X-Forwarded-For 首段
+    webhook_trusted_proxy_hops: int = 1  # 可信反向代理跳数,trust_forwarded 开启时按此从 XFF 右侧取第 N 段
     alertmanager_auto_threshold: float = 0.9  # AI 信心分数 >= 此值时自动执行修复 (Auto-execute when confidence >= this)
     enable_remediation: bool = True  # False = 仅诊断模式，不执行修复 (False = diagnosis-only demo mode)
     demo_sse_max_clients: int = 50  # SSE 最大并发连接数 (Max concurrent SSE connections for demo)

--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -63,11 +63,17 @@ def _parse_allowed_networks(raw: str) -> list[ipaddress.IPv4Network | ipaddress.
 
 
 def _extract_client_ip(request: Request) -> str | None:
-    """获取客户端 IP；若 webhook_trust_forwarded 开启则取 X-Forwarded-For 首段。"""
+    """获取客户端 IP。
+
+    X-Forwarded-For 最左段可由客户端自填，容易伪造；右侧段由可信代理追加。
+    因此 webhook_trust_forwarded 开启时按可信代理跳数从右侧取第 N 段。
+    """
     if settings.webhook_trust_forwarded:
         fwd = request.headers.get("x-forwarded-for", "")
-        if fwd:
-            return fwd.split(",")[0].strip() or None
+        parts = [part.strip() for part in fwd.split(",") if part.strip()]
+        hops = max(1, settings.webhook_trusted_proxy_hops)
+        if len(parts) >= hops:
+            return parts[-hops]
     return request.client.host if request.client else None
 
 
@@ -242,8 +248,6 @@ async def receive_alertmanager_webhook(
     _token: str = Depends(_verify_webhook_token),
     db: AsyncSession = Depends(get_db),
 ):
-    # IP 白名单在 token 校验之后执行，防止把 IP 配置错误暴露给未认证调用者
-    _enforce_ip_whitelist(request)
     """接收 Prometheus AlertManager webhook 回调。
 
     解析告警 → 映射 Host → 触发 AI 诊断和修复。
@@ -251,6 +255,8 @@ async def receive_alertmanager_webhook(
 
     幂等性: 相同的 alertname + instance + startsAt 在 5 分钟内不会重复处理。
     """
+    # IP 白名单在 token 校验之后执行，防止把 IP 配置错误暴露给未认证调用者
+    _enforce_ip_whitelist(request)
     try:
         payload = await request.json()
     except Exception:

--- a/backend/tests/test_webhook_ip_whitelist.py
+++ b/backend/tests/test_webhook_ip_whitelist.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.routers import webhooks
+
+
+def _request(client_host: str | None = "198.51.100.10", xff: str | None = None):
+    headers = {}
+    if xff is not None:
+        headers["x-forwarded-for"] = xff
+    client = SimpleNamespace(host=client_host) if client_host is not None else None
+    return SimpleNamespace(headers=headers, client=client)
+
+
+@pytest.fixture(autouse=True)
+def _reset_webhook_settings(monkeypatch):
+    monkeypatch.setattr(webhooks.settings, "webhook_trust_forwarded", False)
+    monkeypatch.setattr(webhooks.settings, "webhook_trusted_proxy_hops", 1)
+    monkeypatch.setattr(webhooks.settings, "alertmanager_webhook_allowed_ips", "")
+
+
+def test_extract_client_ip_ignores_xff_when_forwarded_not_trusted():
+    request = _request(client_host="198.51.100.10", xff="spoofed, 203.0.113.7")
+
+    assert webhooks._extract_client_ip(request) == "198.51.100.10"
+
+
+def test_extract_client_ip_uses_xff_from_right_by_trusted_hops(monkeypatch):
+    monkeypatch.setattr(webhooks.settings, "webhook_trust_forwarded", True)
+
+    assert webhooks._extract_client_ip(_request(xff="203.0.113.7")) == "203.0.113.7"
+    assert webhooks._extract_client_ip(_request(xff="spoofed, 203.0.113.7")) == "203.0.113.7"
+
+    monkeypatch.setattr(webhooks.settings, "webhook_trusted_proxy_hops", 2)
+
+    assert webhooks._extract_client_ip(_request(xff="spoofed, 203.0.113.7")) == "spoofed"
+
+
+def test_extract_client_ip_falls_back_to_socket_ip_when_xff_unusable(monkeypatch):
+    monkeypatch.setattr(webhooks.settings, "webhook_trust_forwarded", True)
+    monkeypatch.setattr(webhooks.settings, "webhook_trusted_proxy_hops", 2)
+
+    assert webhooks._extract_client_ip(_request(xff="203.0.113.7")) == "198.51.100.10"
+    assert webhooks._extract_client_ip(_request(xff=None)) == "198.51.100.10"
+    assert webhooks._extract_client_ip(_request(xff=" , ")) == "198.51.100.10"
+
+
+def test_parse_allowed_networks_accepts_ips_and_cidrs_and_skips_invalid():
+    networks = webhooks._parse_allowed_networks(
+        "198.51.100.10, 203.0.113.0/24, 2001:db8::/32, not-an-ip"
+    )
+
+    assert [str(network) for network in networks] == [
+        "198.51.100.10/32",
+        "203.0.113.0/24",
+        "2001:db8::/32",
+    ]
+
+
+def test_enforce_ip_whitelist_allows_when_config_empty(monkeypatch):
+    monkeypatch.setattr(webhooks.settings, "alertmanager_webhook_allowed_ips", "")
+
+    webhooks._enforce_ip_whitelist(_request(client_host="198.51.100.10"))
+
+
+def test_enforce_ip_whitelist_allows_matching_client_ip(monkeypatch):
+    monkeypatch.setattr(webhooks.settings, "alertmanager_webhook_allowed_ips", "198.51.100.0/24")
+
+    webhooks._enforce_ip_whitelist(_request(client_host="198.51.100.10"))
+
+
+def test_enforce_ip_whitelist_rejects_unmatched_client_ip(monkeypatch):
+    monkeypatch.setattr(webhooks.settings, "alertmanager_webhook_allowed_ips", "203.0.113.0/24")
+
+    with pytest.raises(HTTPException) as exc_info:
+        webhooks._enforce_ip_whitelist(_request(client_host="198.51.100.10"))
+
+    assert exc_info.value.status_code == 403
+
+
+def test_enforce_ip_whitelist_rejects_unavailable_client_ip(monkeypatch):
+    monkeypatch.setattr(webhooks.settings, "alertmanager_webhook_allowed_ips", "198.51.100.0/24")
+
+    with pytest.raises(HTTPException) as exc_info:
+        webhooks._enforce_ip_whitelist(_request(client_host=None))
+
+    assert exc_info.value.status_code == 403
+
+
+def test_enforce_ip_whitelist_rejects_invalid_client_ip(monkeypatch):
+    monkeypatch.setattr(webhooks.settings, "alertmanager_webhook_allowed_ips", "198.51.100.0/24")
+
+    with pytest.raises(HTTPException) as exc_info:
+        webhooks._enforce_ip_whitelist(_request(client_host="not-an-ip"))
+
+    assert exc_info.value.status_code == 403
+
+
+def test_receive_alertmanager_webhook_docstring_restored():
+    assert webhooks.receive_alertmanager_webhook.__doc__ is not None
+    assert "接收 Prometheus AlertManager webhook" in webhooks.receive_alertmanager_webhook.__doc__


### PR DESCRIPTION
> ⚠️ Stacked PR:基于 #51 的分支,先合 #51,GitHub 会自动把本 PR 重定向到 main。

## 背景
#43 安全补评审 Major 2 + Minor:
- `_extract_client_ip` 在 `webhook_trust_forwarded=True` 时取 XFF **最左段**——客户端自填可伪造,代理为追加模式时可绕过 IP 白名单;
- `webhooks.py` 中 `_enforce_ip_whitelist(request)` 写在 docstring 之前,`__doc__` 失效。

## 修复
- 新增配置 `webhook_trusted_proxy_hops: int = 1`,开启信任时从 XFF **右侧**取第 N 段(右段由可信代理追加);段数不足/头缺失回退 socket 对端 IP;
- `webhook_trust_forwarded` 默认 False 不变,token 校验在前、IP 白名单在后的顺序不变;
- docstring 恢复为函数体首条语句(已断言 `__doc__` 非空)。

## 测试
- 新增 `tests/test_webhook_ip_whitelist.py` 10 例纯单元(不依赖 Postgres):XFF 提取(伪造最左段不生效/hops/回退)、白名单解析与匹配(v4/v6/CIDR/非法条目)、docstring 恢复——全过。
- 全量 pytest:624 passed,无回归。

Authored-by: codex, Reviewed-by: claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)