### PR TITLE
fix: pytest 退出挂死 + 解除 4 用例本地 Postgres 硬依赖(套件全绿)

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -19,6 +19,7 @@ os.environ["POSTGRES_PORT"] = "5432"
 os.environ["REDIS_HOST"] = "localhost"
 os.environ["AI_API_KEY"] = "test-key"
 os.environ["MEMORY_ENABLED"] = "false"
+os.environ["ALERTMANAGER_WEBHOOK_TOKEN"] = "test-webhook-token"
 
 from app.core.database import Base, get_db
 from app.core.security import create_access_token, hash_password
@@ -34,6 +35,12 @@ TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
 from sqlalchemy import event, BigInteger
 
 engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+
+# 服务层(OpsAgentLoop、alert_engine 等)模块级 import 了 app.core.database.async_session,
+# 绕过 get_db 依赖覆盖直连真实 Postgres。就地改绑到测试引擎(StaticPool 共享同一
+# in-memory 连接),让这些直连路径跑在 SQLite 上而不是要求本地 5432。
+import app.core.database as _database_module
+_database_module.async_session.configure(bind=engine)
 
 # Register PostgreSQL functions for SQLite compatibility
 @event.listens_for(engine.sync_engine, "connect")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -399,3 +399,12 @@ async def auth_headers(admin_token: str) -> dict:
 async def viewer_headers(viewer_token: str) -> dict:
     """只读用户认证头。"""
     return {"Authorization": f"Bearer {viewer_token}"}
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """会话结束时释放连接池。
+
+    aiosqlite 每个连接持有一个非 daemon 工作线程；引擎不 dispose 时,
+    池内连接的线程会在解释器退出阶段死等队列,导致 pytest 挂死。
+    """
+    asyncio.run(engine.dispose())

--- a/backend/tests/test_ops_command_flow.py
+++ b/backend/tests/test_ops_command_flow.py
@@ -11,6 +11,7 @@ from app.models.ops_session import OpsSession
 from app.models.user import User
 from app.services import ops_agent_loop as loop_module
 from app.services.ops_agent_loop import OpsAgentLoop
+from app.tools import init_tool_registry, tool_registry
 from tests.conftest import TestingSessionLocal
 
 
@@ -34,6 +35,12 @@ class _FakePubSub:
 
     async def close(self):
         await self.unsubscribe()
+
+    async def get_message(self, ignore_subscribe_messages: bool = True, timeout: float = 0):
+        try:
+            return await asyncio.wait_for(self._queue.get(), timeout=timeout or None)
+        except asyncio.TimeoutError:
+            return None
 
     async def listen(self):
         while True:
@@ -78,6 +85,9 @@ async def _wait_event(events: list[dict], event_name: str, timeout: float = 3.0)
 
 @pytest.mark.asyncio
 async def test_ops_command_confirm_execute_and_result_back(monkeypatch):
+    if tool_registry.tool_count == 0:
+        init_tool_registry()
+
     fake_redis = _FakeRedis()
     async def _fake_get_redis():
         return fake_redis
@@ -108,14 +118,18 @@ async def test_ops_command_confirm_execute_and_result_back(monkeypatch):
         await db.commit()
         await db.refresh(host)
 
-        session = OpsSession(id="sess-ops-flow", user_id=user.id, title="ops-flow")
+        session = OpsSession(
+            id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1",
+            user_id=user.id,
+            title="ops-flow",
+        )
         db.add(session)
         await db.commit()
 
     # mock AI：第一轮只发 execute_command，第二轮给结论文本后结束
     call_round = {"n": 0}
 
-    async def fake_call_api_stream(self):
+    async def fake_call_api_stream(self, _runtime_cfg=None):
         call_round["n"] += 1
         if call_round["n"] == 1:
             yield {

--- a/backend/tests/test_ops_session_routes.py
+++ b/backend/tests/test_ops_session_routes.py
@@ -8,8 +8,10 @@
 3. 顺手清理用户残留的空白草稿（无消息无标题），避免堆积
 4. 不删除带消息或带标题的会话
 """
+from datetime import datetime, timedelta, timezone
+
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from app.models.ops_message import OpsMessage
 from app.models.ops_session import OpsSession
@@ -43,10 +45,18 @@ async def test_post_sessions_persists_title(client, auth_headers):
 async def test_post_sessions_cleans_up_empty_drafts(client, auth_headers, db_session, admin_user):
     """连续创建 3 次后，DB 里只应该剩下最新的那一个空白草稿。"""
     ids = []
-    for _ in range(3):
+    for idx in range(3):
         r = await client.post("/api/v1/ops/sessions", json={}, headers=auth_headers)
         assert r.status_code == 200
         ids.append(r.json()["id"])
+        if idx < 2:
+            stale_at = datetime.now(timezone.utc) - timedelta(seconds=120)
+            await db_session.execute(
+                update(OpsSession)
+                .where(OpsSession.id == ids[-1])
+                .values(created_at=stale_at, updated_at=stale_at)
+            )
+            await db_session.commit()
 
     # 三个 id 都不同
     assert len(set(ids)) == 3

--- a/backend/tests/test_ops_tool_call_order.py
+++ b/backend/tests/test_ops_tool_call_order.py
@@ -4,11 +4,15 @@ import json
 
 import pytest
 
+from app.tools import init_tool_registry, tool_registry
 from app.services.ops_agent_loop import OpsAgentLoop
 
 
 @pytest.mark.asyncio
 async def test_load_skill_keeps_tool_protocol_order(monkeypatch):
+    if tool_registry.tool_count == 0:
+        init_tool_registry()
+
     loop = OpsAgentLoop("sess-order", 1)
     loop._context = [{"role": "system", "content": "sys"}]
 
@@ -16,14 +20,17 @@ async def test_load_skill_keeps_tool_protocol_order(monkeypatch):
     async def _noop_save(*args, **kwargs):
         return "msg-1"
 
+    async def _none_session():
+        return None
+
     monkeypatch.setattr(loop, "_save_message", _noop_save)
-    monkeypatch.setattr(loop, "_get_session", lambda: None)
+    monkeypatch.setattr(loop, "_get_session", _none_session)
     monkeypatch.setattr(loop, "_compact_context", lambda: asyncio.sleep(0))
 
     # 第一轮触发 load_skill，第二轮结束
     round_idx = {"n": 0}
 
-    async def fake_call_api_stream():
+    async def fake_call_api_stream(_runtime_cfg=None):
         round_idx["n"] += 1
         if round_idx["n"] == 1:
             yield {


### PR DESCRIPTION
## 内容(两个原子提交)

**1bfc937 — pytest 结束后进程挂死**
conftest 模块级 aiosqlite 引擎从未 dispose,池内每个连接持有一个非 daemon `_connection_worker_thread`,解释器退出阶段死等队列。新增 `pytest_sessionfinish` 钩子 `asyncio.run(engine.dispose())`。修复后全量 pytest 结束进程自行退出(此前永久挂死需 kill)。

**5ee75dd — 解除 4 个用例对本地 Postgres 的硬依赖**
- 服务层(OpsAgentLoop 等)模块级直连 `app.core.database.async_session`,绕过 `get_db` 依赖覆盖 → conftest 就地 `configure(bind=测试引擎)`(StaticPool 共享内存库);
- 测试环境补 `ALERTMANAGER_WEBHOOK_TOKEN`(webhook 认证用例从 503 回到 401 语义);
- 修复三处被连接失败长期掩盖的测试缺陷:`_get_session` 同步 mock 被 await、`OpsSession` 测试 id 非法 UUID、空白草稿清理断言未跟上 375d536 的 60 秒保护(行为正确,对齐测试)。

## 测试
本地**无 Postgres** 环境:全量 pytest **610 passed, 0 failed**(套件首次全绿),进程 5m34s 自行退出。CI(有 Postgres services)不受影响,直连路径统一走 SQLite 更 hermetic。

1bfc937: Authored-by: claude, Reviewed-by: codex
5ee75dd: Authored-by: codex (tests) + claude (conftest), Reviewed-by: claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)