### PR TITLE
fix: requirements.txt 补充 aiosqlite(conftest 测试引擎所需)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.115.6
 uvicorn[standard]==0.35.0
 sqlalchemy[asyncio]==2.0.36
 asyncpg==0.30.0
+aiosqlite==0.22.1  # 测试库驱动(tests/conftest.py 的 sqlite+aiosqlite 引擎)
 alembic==1.14.1
 redis[hiredis]==5.2.1
 pydantic-settings==2.7.1


### PR DESCRIPTION
## 背景
`tests/conftest.py` 使用 `sqlite+aiosqlite` 引擎但依赖未声明;CI 在 test.yml 单独 `pip install aiosqlite` 掩盖了缺口,本地干净环境装完 requirements 后 pytest 收集即报缺依赖。

## 修复
`aiosqlite==0.22.1` 加入 DB 驱动组,锁定当前使用版本。

## 验证
干净 venv 仅装 requirements(+pytest/pytest-asyncio):收集正常,test_auth 10 passed。

Authored-by: claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)